### PR TITLE
Add workflow and action to build and deploy the documentation

### DIFF
--- a/.github/actions/install-minterpy/action.yaml
+++ b/.github/actions/install-minterpy/action.yaml
@@ -1,0 +1,23 @@
+name: install-minterpy
+description: Common steps for installing Minterpy
+inputs:
+  extras_require:
+      description: 'Extras feature specification'
+      required: false
+      default: ''
+runs:
+  using: 'composite'
+  steps:
+    - name: Install Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+    - name: Create a virtual environment
+      shell: bash
+      run: |
+        python -m venv venv
+        source venv/bin/activate
+    - name: Install docs dependencies
+      shell: bash
+      run: |
+        pip install -e .${{ inputs.extras_require }}

--- a/.github/workflows/docs-preview.yaml
+++ b/.github/workflows/docs-preview.yaml
@@ -1,0 +1,69 @@
+name: docs-preview
+
+on: 
+  pull_request:
+    branches: ["dev", "main"]
+    types: [opened, synchronize, closed]
+
+permissions:
+  id-token: write
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  docs_preview:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'opened' || github.event.action == 'synchronize' 
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: Install Minterpy with docs extras
+        uses: ./.github/actions/install-minterpy
+        with:
+          extras_require: "[docs]"
+      - name: Turn off notebook execution mode
+        run: |
+          sed -i 's/^nb_execution_mode = "auto"$/nb_execution_mode = "off"/' ./docs/conf.py
+      - name: Build the docs
+        run: |
+          sphinx-build docs _build
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/
+          destination_dir: pr-preview/${{ github.event.number }}
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Documentation preview (without executed notebooks) is [available](https://minterpy-project.github.io/minterpy/pr-preview/${{ github.event.number }}).'
+            })
+
+  docs_preview_cleanup:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Remove preview
+        run: |
+          git rm -r pr-preview/${{ github.event.number }}
+          git commit -m "Remove preview for PR #${{ github.event.number }}"
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,38 @@
+name: docs
+
+on:
+  push:
+    branches: ["dev", "main"]
+
+permissions:
+  contents: write
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      - name: Install Minterpy with docs extras
+        uses: ./.github/actions/install-minterpy
+        with:
+          extras_require: "[docs]"
+      - name: Build the docs
+        run: |
+          sphinx-build docs _build 
+      - name: Deploy to GitHub Pages (Latest)
+        uses: peaceiris/actions-gh-pages@v4
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/dev' }}
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/
+          destination_dir: ./latest
+      - name: Deploy to GitHub Pages (Stable)
+        uses: peaceiris/actions-gh-pages@v4
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/
+          destination_dir: ./stable

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@
 
 ---
 
+|                                  Branches                                  | Status                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+|:--------------------------------------------------------------------------:|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [`main`](https://github.com/minterpy-project/minterpy/tree/main) (stable)  | [![Documentation Build and Deployment](https://github.com/minterpy-project/minterpy/actions/workflows/docs.yaml/badge.svg?branch=main)](https://minterpy-project.github.io/minterpy/stable/) |
+|  [`dev`](https://github.com/minterpy-project/minterpy/tree/dev) (latest)   | [![Documentation Build and Deployment](https://github.com/minterpy-project/minterpy/actions/workflows/docs.yaml/badge.svg?branch=dev)](https://minterpy-project.github.io/minterpy/latest/)  |
+
 `minterpy` is an open-source Python package for a multivariate generalization
 of the classical Newton and Lagrange interpolation schemes as well as related tasks.
 It is based on an optimized re-implementation of

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,12 +141,31 @@ html_theme_options = {
     "icon_links": [
             {
                 "name": "GitHub",
-                "url": "https://github.com/casus/minterpy",
+                "url": "https://github.com/minterpy-project/minterpy",
                 "icon": "fa-brands fa-square-github",
+                "type": "fontawesome",
+            },
+            {
+                "name": "Latest Docs",
+                "url": "https://minterpy-project.github.io/minterpy/latest/",
+                "icon": "fa-brands fa-dev",
+                "type": "fontawesome",
+            },
+            {
+                "name": "Stable Docs",
+                "url": "https://minterpy-project.github.io/minterpy/stable/",
+                "icon": "fa-solid fa-box-open",
                 "type": "fontawesome",
             },
     ],
 }
+
+suppress_warnings = [
+    'autosummary.import_cycle',
+]
+
+# Flag to execute notebooks-based documentation during build
+nb_execution_mode = "auto"
 
 # --- Custom directives -------------------------------------------------------
 


### PR DESCRIPTION
Two workflows are added:

- Building and deploying documentation whenever there is a push to the `main` and `dev` branches.
- Building and deploying a documentation preview (without executing notebooks to save time) whenever there is a pull request to the `main` and `dev` branches.

This PR is related to Issue #2.