### PR TITLE
Fix issue with the Quickstart Guide

### DIFF
--- a/docs/getting-started/function-approximations.ipynb
+++ b/docs/getting-started/function-approximations.ipynb
@@ -27,8 +27,7 @@
    "source": [
     "Welcome to the Quickstart Guide to Minterpy!\n",
     "\n",
-    "If you're here, you likely want to create an interpolant that approximates a function, possibly in multiple dimensions.\n",
-    "This guide will quickly show you how to do that using Minterpy."
+    "If you're reading this, chances are you want to create an interpolant that approximates a function, possibly in multiple dimensions. This guide provides a quick walkthrough on how to achieve this using Minterpy."
    ]
   },
   {
@@ -214,19 +213,25 @@
    "source": [
     "### One-dimensional interpolant\n",
     "\n",
-    "To create an interpolant in Minterpy, you can use the function {py:func}`.interpolate` which takes the following argument (in order):\n",
+    "To create an interpolant in Minterpy, use the {py:func}`.interpolate` function which accepts the following arguments in order:\n",
     "\n",
-    "- the function to interpolate (a callable that takes an array of input values and returns an array of output values of the same length)\n",
-    "- the spatial dimension of the function\n",
-    "- the degree of the polynomial interpolant\n",
+    "1. The function to interpolate (a callable that takes an array of input values and returns an array of output values of the same length)\n",
+    "2. The spatial dimension of the function\n",
+    "3. The degree of the polynomial interpolant\n",
     "\n",
     "The lambda function you've defined above already satisfies the first requirement: as a callable, it takes an array of input values and returns an array of output values.\n",
     "\n",
-    "The spatial dimension of the function is $1$; since Minterpy cannot infer the dimensionality of your function, you need to specify this.\n",
+    "The spatial dimension of the function, which represents the number of input variables it accepts, is $1$. Since Minterpy cannot automatically infer the dimensionality of your function, you must specify this value explicitly.\n",
     "\n",
-    "Finally, you need to choose the degree of the polynomial interpolant. Since Minterpy interpolants are based on polynomials, specifying the degree in advance is necessary. As a best practice, you should later verify whether the interpolant achieves sufficient accuracy.\n",
-    "\n",
-    "Let's say that the chosen polynomial degree is $8$:"
+    "Finally, you need to specify the degree of the polynomial interpolant. Because Minterpy interpolants are based on polynomials, it is necessary to choose the polynomial degree in advance. As a best practice, it is recommended to verify the accuracy of the interpolant after creation to ensure it meets your requirements."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e3e0d90-e220-452c-8c54-e6930b8f6d43",
+   "metadata": {},
+   "source": [
+    "For instance, let's say you choose a polynomial degree of $8$:"
    ]
   },
   {
@@ -339,7 +344,7 @@
     "tags": []
    },
    "source": [
-    "It seems that the interpolant still a bit off and does not approximate the function nicely."
+    "However, the interpolant doesn't quite match the function as closely as we'd like."
    ]
   },
   {
@@ -407,7 +412,7 @@
     "tags": []
    },
    "source": [
-    "Whether the given norm is sufficiently low depends on your application. But we might agree, for now, that the number above is hardly a numerical convergence."
+    "Whether the given norm is low enough depends on what you're using the interpolant for. But for now, let's agree that the number above isn't exactly a numerical convergence."
    ]
   },
   {
@@ -489,8 +494,15 @@
     "tags": []
    },
    "source": [
-    "Visually, there is no notable difference between the interpolant of degree $32$ and the original function.\n",
-    "And indeed the infinity norm is now:"
+    "Looking at the graph, it's hard to see any difference between the interpolant of degree $32$ and the original function."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "925c1c2f-901e-4661-8bd5-9644bec6bf05",
+   "metadata": {},
+   "source": [
+    "Looking at the infinity norm:"
    ]
   },
   {
@@ -522,7 +534,7 @@
     "tags": []
    },
    "source": [
-    "which is close to numerical convergence."
+    "which is now closer to numerical convergence."
    ]
   },
   {
@@ -538,7 +550,7 @@
    "source": [
     "## Two-dimensional function\n",
     "\n",
-    "Consider now two-dimensional function:\n",
+    "Consider now a two-dimensional function:\n",
     "\n",
     "$$\n",
     "f(x_1, x_2) = \\sin{\\pi (1.5 x_1 + 2.5 x_2)}, x_1, x_2 \\in [-1, 1].\n",
@@ -662,14 +674,20 @@
    "source": [
     "### Two-dimension interpolant\n",
     "\n",
-    "The function {py:func}`.interpolate` also accepts two-dimensional functions for interpolation. Here are a few things to note:\n",
+    "The function {py:func}`.interpolate` can also handle two-dimensional functions. Here are a few things to note:\n",
     "\n",
-    "- The function must accept a two-dimensional array as input, where each row corresponds to input values in multiple dimensions, and each column corresponds to input values for each spatial dimension. In this case, the input array is expected to have $2$ columns (for spatial dimension $2$). Furthermore, the function must return an array with the same length as the length of the input (i.e., the number of rows).\n",
-    "- As previously mentioned, you need to specify that the function to interpolate has a spatial dimension of $2$.\n",
+    "- Your function should take a two-dimensional (2D) array as input, where each row represents a point in space and each column corresponds to a spatial dimension. For functions defined in 2D space, this means the input array must have exactly two columns. The function should return an array with the same number of rows as the input.\n",
+    "- As mentioned earlier, make sure to specify that your function has a spatial dimension of $2$ when calling {py:func}`.interpolate`. \n",
     "\n",
-    "Additionally, when the spatial dimension is more than $1$, there is one more argument you can specify: the $l_p$-degree. This degree is related to the specification of the underlying multi-index set of exponents. Some choices of $l_p$-degree may approximate a given function better than others. See the {ref}`relevant section <fundamentals/polynomial-bases:Multi-index sets and polynomial degree>` for details. This argument is optional, with the default value set to $2.0$.\n",
-    "\n",
-    "To create a two-dimensional interpolant with a polynomial degree of $32$, you would proceed as follows:"
+    "One more thing to note: when you're working with functions of more than one spatial dimension, you can also specify the $l_p$-degree argument. This controls the underlying multi-index set of exponents used in the interpolation. Different $l_p$-degree values can affect how well the interpolant approximates the original function. Checkout the {ref}`relevant section <fundamentals/polynomial-bases:Multi-index sets and polynomial degree>` for details. If you don't specify an $l_p$-degree, it defaults to $2.0$."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36208d48-84e6-40fc-8e89-c96834401593",
+   "metadata": {},
+   "source": [
+    "To create a two-dimensional interpolant with a polynomial degree of $32$, use the following command:"
    ]
   },
   {
@@ -774,8 +792,14 @@
    "source": [
     "### Assessing 2D interpolant accuracy\n",
     "\n",
-    "It is hard by looking at the plot above to conclude that interpolant is accurate enough; the interpolant does capture the overall shape of the original function, though.\n",
-    "\n",
+    "Just by looking at the plot, it's though to say for sure if the interpolant is accurate enough. But it does seem to capture the overall shape of the function pretty well."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e3edf8d-1af2-4693-a47d-fb5af8ff144f",
+   "metadata": {},
+   "source": [
     "As explained previously, you can use the infinity norm to quantify the accuracy of the interpolant.\n",
     "To estimate it using, say, $100'000$ random points in $[-1, 1]^2$:"
    ]
@@ -825,7 +849,7 @@
    "source": [
     "## Four-dimensional function\n",
     "\n",
-    "You've seen how to interpolate a one-dimensional and a two-dimensional function. How about functions in higher dimension?\n",
+    "So far, you've seen how to interpolate 1D and 2D functions. But what about functions with even more dimensions?\n",
     "\n",
     "Consider now the $m$-dimensional Runge function:\n",
     "\n",
@@ -883,13 +907,19 @@
    "source": [
     "### Four-dimension interpolant\n",
     "\n",
-    "The choice of the function above is to demonstrate that the function {py:func}`.interpolate` works the same way as it does for one- and two-dimensional functions.\n",
+    "The $m$-dimensional Runge function defined above is chosen to show that {py:func}`.interpolate` works the same way for higher-dimensional functions as it does for 1D and 2D ones.\n",
     "\n",
-    "You just need to ensure that the function to interpolate conforms to Minterpy's requirements: it should be a callable that accepts a two-dimensional array where each row corresponds to a point in a multi-dimensional space, and each column corresponds to values in the spatial dimension.\n",
+    "Just make sure your function meets Minterpy's requirements: it should be a callable that takes a 2D array as input, where each row represents a point in multidimensional space and each column corresponds to a spatial dimension (so in this case, four columns).\n",
     "\n",
-    "Similar to the two-dimensional case, you have the option to adjust the $l_p$-degree of the underlying multi-index set. Again, this is optional.\n",
-    "\n",
-    "To create a four-dimensional interpolant with a polynomial degree of $16$, you would proceed as follows:"
+    "Just like with 2D functions, you can also tweak the $l_p$-degree of the underlying multi-index set for higher-dimensional functions ($m > 1$). This is optional, but can affect the accuracy of the interpolant."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0691001-8113-4c68-b551-eef683b89236",
+   "metadata": {},
+   "source": [
+    "To create a 4D interpolant with a polynomial degree of $16$, use the following command:"
    ]
   },
   {
@@ -921,8 +951,8 @@
    "source": [
     "### Assessing 4D interpolant accuracy\n",
     "\n",
-    "Just, you can use the infinity norm to quantify the accuracy of the interpolant.\n",
-    "To estimate it using, say, $10'000$ random points in $[-1, 1]^4$:"
+    "As before, you use the infinity norm to gauge the accuracy of the interpolant. To estimate it using \n",
+    "$10'000$ random points in $[-1, 1]^4$, you can use the following code:"
    ]
   },
   {
@@ -995,7 +1025,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.9.19"
   }
  },
  "nbformat": 4,

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -50,7 +50,7 @@ What's next?
 If you're brand new to Minterpy and simply want to approximate a function using
 polynomial interpolations, start with:
 
-:doc:`functions-approximation`
+:doc:`function-approximations`
 
 While approximating functions using polynomials is a main feature of Minterpy,
 it also offers multi-dimensional polynomials in Python.
@@ -88,7 +88,7 @@ a particular task, be sure to check out the :doc:`/how-to/index`!
    :maxdepth: 1
    :hidden:
 
-   Functions approximation <functions-approximation>
+   Function Approximations <function-approximations>
    1D Polynomial Interpolation <1d-polynomial-interpolation>
    mD Polynomial Interpolation <md-polynomial-interpolation>
    Arithmetic with Polynomials <arithmetic-operations-with-polynomials>

--- a/docs/getting-started/polynomial-bases-and-transformations.ipynb
+++ b/docs/getting-started/polynomial-bases-and-transformations.ipynb
@@ -2598,7 +2598,7 @@
    "source": [
     "## From interpolant to interpolating polynomial\n",
     "\n",
-    "The {doc}`Quickstart Guide </getting-started/functions-approximation>` introduced\n",
+    "The {doc}`Quickstart Guide </getting-started/function-approximations>` introduced\n",
     "you with the {py:func}`interpolate() <.interpolation.interpolate>` function to\n",
     "conveniently create an interpolant out of a function for a given spatial\n",
     "dimension, polynomial degree, and $l_p$-degree.\n",


### PR DESCRIPTION
The Quickstart guide (function approximations with Minterpy) has been revised to  fix typos and grammatical mistakes. Furthermore, several sentences have been reformulated for clarity.

This PR should resolve Issue #21.