### PR TITLE
Implement Domain class for rectangular domain transformations

### DIFF
--- a/src/minterpy/core/__init__.py
+++ b/src/minterpy/core/__init__.py
@@ -32,6 +32,11 @@ from .multi_index import *  # noqa
 
 __all__ += multi_index.__all__
 
+from . import domain  # noqa
+from .domain import *  # noqa
+
+__all__ += domain.__all__
+
 from . import grid  # noqa
 from .grid import *  # noqa
 

--- a/src/minterpy/core/domain.py
+++ b/src/minterpy/core/domain.py
@@ -1,0 +1,319 @@
+"""
+This module contains the implementation of the `Domain` class.
+
+The `Domain` class represents the domain of the polynomials, i.e., the set of
+all input points for which the polynomials are defined. As the internals of
+Minterpy work for interpolating polynomial in the so-called "normalized"
+domain (i.e., :math:`[-1, 1]^m`), the class provides convenient methods for:
+
+- transformation of values to/from normalized domain in :math:`[-1, 1]^m`
+- computing the scaling factor in polynomial differentiation
+- computing the scaling factor in polynomial integration
+
+The main assumption of the transformation is that the transformation is
+affine applied to each dimension separately.
+"""
+import numpy as np
+
+from minterpy.global_settings import FLOAT_DTYPE
+from minterpy.utils.verification import verify_domain_bounds
+
+__all__ = ["Domain"]
+
+
+class Domain:
+    """A class representing the domain of the polynomials.
+
+    A domain of a polynomial is the set of all input points
+    for which the polynomials are defined.
+    A domain is defined by the lower and upper bounds per dimension.
+    Currently, only domains with finite bounds are supported.
+
+    Parameters
+    ----------
+    bounds : np.ndarray
+        The domain bounds as a 2D array with shape (m, 2),
+        where m is the spatial dimension.
+        The first column contains the lower bounds and the second column
+        the upper bounds across dimensions.
+    """
+
+    def __init__(self, bounds: np.ndarray):
+
+        # Verify and assign the bounds
+        self.bounds = verify_domain_bounds(bounds)
+
+    # --- Factory methods
+    @classmethod
+    def uniform(
+        cls,
+        spatial_dimension: int,
+        lower_bound: float,
+        upper_bound: float,
+    ):
+        """Create an instance of Domain with uniform bounds across dimensions.
+
+        Creates a hyper-rectangular domain :math:`[a, b]^m` where :math:`a`
+        and :math:`b` are the lower and upper bounds for each dimension,
+        respectively.
+
+        Parameters
+        ----------
+        spatial_dimension : int
+            The number of dimensions for the space.
+        lower_bound : float
+            The lower bound of each dimension.
+        upper_bound : float
+            The upper bound of each dimension.
+
+        Returns
+        -------
+        Domain
+            A new instance of the `Domain` class initialized with uniform
+            bounds, i.e., the same lower and upper bound for all dimensions.
+        """
+        bounds = np.empty((spatial_dimension, 2), dtype=FLOAT_DTYPE)
+        bounds[:, 0] = lower_bound
+        bounds[:, 1] = upper_bound
+
+        return cls(bounds)
+
+    @classmethod
+    def normalized(cls, spatial_dimension: int):
+        """Create an instance of Domain with [-1, 1] bound across dimensions.
+
+        Parameters
+        ----------
+        spatial_dimension : int
+            The number of dimensions for the space.
+
+        Returns
+        -------
+        Domain
+            A new instance of the `Domain` class initialized with normalized
+            bounds, i.e., :math:`[-1, 1]^m` where :math:`m`
+            is the spatial dimension.
+        """
+        bounds = np.empty((spatial_dimension, 2), dtype=FLOAT_DTYPE)
+        bounds[:, 0] = -1.0
+        bounds[:, 1] = 1.0
+
+        return cls(bounds)
+
+    # --- Properties
+    @property
+    def spatial_dimension(self):
+        """Dimension of the domain space.
+        
+        Return
+        ------
+        int
+            The dimension of the domain space.
+        """
+        return len(self.bounds)
+
+    @property
+    def lower_bounds(self) -> np.ndarray:
+        """The lower bounds of the domain.
+
+        Returns
+        -------
+        np.ndarray
+            The lower bounds of the domain as a one-dimensional array having
+            shape ``(m, )``.
+        """
+        return self.bounds[:, 0]
+
+    @property
+    def upper_bounds(self) -> np.ndarray:
+        """The upper bounds of the domain.
+
+        Returns
+        -------
+        np.ndarray
+            The upper bounds of the domain as a one-dimensional array having
+            shape ``(m, )``.
+        """
+        return self.bounds[:, 1]
+
+    @property
+    def domain_widths(self) -> np.ndarray:
+        """The widths of the domain.
+
+        Returns
+        -------
+        np.ndarray
+            The difference between the upper and lower bounds of the domain
+            as a one-dimensional array having shape ``(m, )``.
+        """
+        return self.upper_bounds - self.lower_bounds
+
+    @property
+    def is_normalized(self) -> bool:
+        """Check whether the domain is normalized.
+
+        Returns
+        -------
+        bool
+            ``True`` if the domain is normalized, ``False`` otherwise.
+        """
+        return (
+            np.all(self.lower_bounds == -1.0) and
+            np.all(self.upper_bounds == 1.0)
+        )
+
+    # --- Instance methods
+    def map_to_normalized(
+        self,
+        xx: np.ndarray,
+        validate: bool = False,
+    ) -> np.ndarray:
+        """Map input points to normalized :math:`[-1, 1]^m` domain.
+
+        Parameters
+        ----------
+        xx : :class:`numpy:numpy.ndarray`
+            The input points to be mapped to the normalized domain.
+        validate : bool, optional
+            If True, validate that input points are within domain bounds, i.e.,
+            no extrapolation is allowed.
+
+        Returns
+        -------
+        :class:`numpy:numpy.ndarray`
+            The normalized points in :math:`[-1, 1]^m` domain, except when
+            extrapolated (with ``validate=False``).
+        """
+        if validate and not np.all(self.contains(xx)):
+            raise ValueError(
+                "Input points are outside of domain bounds. "
+                "Set validate=False to allow extrapolation."
+            )
+
+        return -1 + 2 * (xx - self.lower_bounds) / self.domain_widths
+
+    def map_from_normalized(
+        self,
+        xx: np.ndarray,
+        validate: bool = False,
+    ) -> np.ndarray:
+        """Map normalized points in :math:`[-1, 1]^m` to the original domain.
+
+        Parameters
+        ----------
+        xx : :class:`numpy:numpy.ndarray`
+            The input points in the normalized domain to be mapped
+            to the original domain.
+        validate : bool, optional
+            If True, validate that input points are within domain bounds, i.e.,
+            no extrapolation is allowed.
+
+        Returns
+        -------
+        :class:`numpy:numpy.ndarray`
+            The points in the original domain.
+        """
+        if validate and not np.all((xx <= 1.0) & (xx >= -1.0)):
+            raise ValueError(
+                "Input points are outside of [-1, 1]^m domain. "
+                "Set validate=False to allow extrapolation."
+            )
+
+        return self.lower_bounds + (xx + 1) / 2 * self.domain_widths
+
+    def get_int_factor(self) -> float:
+        """Compute the scaling factor for polynomial integration.
+
+        Returns
+        -------
+        float
+            The scaling factor for polynomial integration.
+
+        Notes
+        -----
+        - Here, we assume that the integration is carried out over all
+          dimensions.
+        """
+        return float(np.prod(self.domain_widths / 2.0))
+
+    def get_diff_factor(self, order: np.ndarray) -> float:
+        """Compute the scaling factor for polynomial differentiation.
+
+        Parameters
+        ----------
+        order : :class:`numpy:numpy.ndarray`
+            A one-dimensional integer array specifying the order of derivatives
+            along each dimension. The length of the array must be ``m`` where
+            ``m`` is the spatial dimension of the polynomial.
+
+        Returns
+        -------
+        float
+            The scaling factor for polynomial differentiation.
+        """
+        idx = order > 0
+
+        return float(np.prod((2.0 / self.domain_widths[idx])**(order[idx])))
+
+    def partial_matching(self, other: "Domain") -> bool:
+        """Compare two instances of domain up to the common dimension.
+
+        Parameters
+        ----------
+        other : Domain
+            An instance of :class:`Domain` that is to be compared with
+            the current instance.
+
+        Returns
+        -------
+        bool
+            ``True`` if the two instances matches up to the common dimension,
+            ``False`` otherwise.
+        """
+        dim = min(self.spatial_dimension, other.spatial_dimension)
+
+        return np.all(self.bounds[:dim, :] == other.bounds[:dim, :])
+
+    def contains(self, xx: np.ndarray) -> np.ndarray:
+        """Check whether the input points are contained in the domain.
+
+        Parameters
+        ----------
+        xx : :class:`numpy:numpy.ndarray`
+            A set of values to be checked.
+
+        Returns
+        -------
+        :class:`numpy:numpy.ndarray`
+            A boolean array indicating whether each point is contained
+            in the domain.
+        """
+        return (
+                np.all(self.lower_bounds <= xx, axis=1)
+                & np.all(xx <= self.upper_bounds, axis=1)
+        )
+
+
+    # --- Dunder methods
+    def __eq__(self, other: "Domain") -> bool:
+        """Compare two instances of Domain for exact equality in value.
+
+        Two instances of :class:`Domain` class is equal in value if
+        and only if both the underlying bounds are equal.
+
+        Parameters
+        ----------
+        other : Domain
+            An instance of :class:`Domain` that is to be compared with
+            the current instance.
+
+        Returns
+        -------
+        bool
+            ``True`` if the two instances are equal in value,
+            ``False`` otherwise.
+        """
+        return (
+            self.spatial_dimension == other.spatial_dimension and
+            np.all(self.bounds == other.bounds)
+        )

--- a/src/minterpy/utils/exceptions.py
+++ b/src/minterpy/utils/exceptions.py
@@ -1,0 +1,12 @@
+"""
+This module contains custom exceptions used across Minterpy.
+"""
+
+class InvalidDomainBoundsError(ValueError):
+    """Raised when domain bounds are invalid."""
+    pass
+
+
+class InvalidDerivativeOrderError(ValueError):
+    """Raised when order of derivatives specification is invalid."""
+    pass

--- a/src/minterpy/utils/verification.py
+++ b/src/minterpy/utils/verification.py
@@ -6,8 +6,18 @@ from typing import Any, List, Optional, Sized, Tuple, Type, TypeVar, Union
 
 import numpy as np
 from _warnings import warn
+from numpy.typing import ArrayLike
 
-from minterpy.global_settings import DEBUG, DEFAULT_DOMAIN, FLOAT_DTYPE, INT_DTYPE
+from minterpy.global_settings import (
+    DEBUG,
+    DEFAULT_DOMAIN,
+    FLOAT_DTYPE,
+    INT_DTYPE,
+)
+from minterpy.utils.exceptions import (
+    InvalidDomainBoundsError,
+    InvalidDerivativeOrderError,
+)
 
 
 def verify_domain(domain, spatial_dimension):
@@ -744,10 +754,10 @@ def verify_query_points(xx: np.ndarray, spatial_dimension: int) -> np.ndarray:
     array([[1.],
            [2.],
            [3.]])
-    >>> verify_query_points(np.array(["a", "b"]), 1)
+    >>> verify_query_points(np.array(["a", "b"]), 1) # doctest: +ELLIPSIS
     Traceback (most recent call last):
     ...
-    ValueError: could not convert string to float: 'a' Invalid values in query points array!
+    ValueError: could not convert string to float: ...
 
     Notes
     -----
@@ -858,6 +868,193 @@ def verify_poly_power(power: int) -> int:
         raise err
 
     return power
+
+def verify_domain_bounds(bounds: ArrayLike) -> np.ndarray:
+    r"""Verify that the given bounds for a domain are valid.
+
+    Valid domain bounds must satisfy the following conditions:
+
+    - Convertible to a 2D numeric array
+    - Shape of ``(m, 2)`` where ``m >= 1`` (dimension is positive)
+    - Finite values (no NaN or inf)
+    - Non-empty
+    - Upper bounds strictly greater than lower bounds for all dimensions
+
+    Parameters
+    ----------
+    bounds : array_like
+        Domain bounds as either a 1D array ``[lower, upper]`` for a single
+        dimension, or a 2D array of shape ``(m, 2)`` for ``m`` dimensions.
+        Each row specifies ``[lower, upper]`` for one dimension.
+
+    Returns
+    -------
+    :class:`numpy:numpy.ndarray`
+        Validated domain bounds as a 2D array of shape ``(m, 2)`` with
+        dtype ``FLOAT_DTYPE``.
+
+    Raises
+    ------
+    InvalidDomainBoundsError
+        If the bounds violate any validation condition (see above).
+
+    Examples
+    --------
+    >>> verify_domain_bounds(np.array([-1, 1]))  # 1D array, single dimension
+    array([[-1.,  1.]])
+    >>> verify_domain_bounds(np.array([[1, 2]]))  # Integer array (auto-converted)
+    array([[1., 2.]])
+    >>> verify_domain_bounds(np.array([[1., 2.], [2., 3.]]))  # 2D domain
+    array([[1., 2.],
+           [2., 3.]])
+    >>> verify_domain_bounds([3, 2]) # doctest: +NORMALIZE_WHITESPACE
+    Traceback (most recent call last):
+    ...
+    minterpy.utils.exceptions.InvalidDomainBoundsError: Upper bounds must be
+    strictly greater than lower bounds.
+    Invalid dimensions: [0]; Invalid bounds: [[3.0, 2.0]]
+    """
+    # Convert to a two-dimensional NumPy array of FLOAT_DTYPE
+    try:
+        bounds = np.atleast_2d(np.array(bounds, dtype=FLOAT_DTYPE))
+    except (TypeError, ValueError) as err:
+        raise InvalidDomainBoundsError(
+            f"Domain bounds must be array-like of numeric values, "
+            f"got {type(bounds).__name__} instead"
+        ) from err
+
+    # Validate dimensionality
+    if bounds.ndim != 2:
+        raise InvalidDomainBoundsError(
+            f"Domain bounds must be 2D after conversion, "
+            f"got {bounds.ndim}D array instead"
+        )
+
+    # Validate non-empty array
+    if bounds.size == 0:
+        raise InvalidDomainBoundsError("Domain bounds cannot be empty")
+
+    # Validate shape
+    if bounds.shape[1] != 2:
+        raise InvalidDomainBoundsError(
+            f"Bounds must have 2 columns [lower, upper], "
+            f"got {bounds.shape[1]} columns instead"
+        )
+
+    # Validate finite values (no Inf and NaN allowed)
+    if not np.isfinite(bounds).all():
+        raise InvalidDomainBoundsError(
+            "Bounds must be finite (no NaN or inf values)"
+        )
+
+    # Validate lower < upper
+    widths = bounds[:, 1] - bounds[:, 0]
+    if np.any(widths <= 0):
+        invalid_dims = np.where(widths <= 0)[0]
+        raise InvalidDomainBoundsError(
+            f"Upper bounds must be strictly greater than lower bounds. "
+            f"Invalid dimensions: {invalid_dims.tolist()}; "
+            f"Invalid bounds: {bounds[invalid_dims].tolist()}"
+        )
+
+    return bounds
+
+
+def verify_derivative_order(
+    order: ArrayLike,
+    spatial_dimension: int,
+) -> np.ndarray:
+    r"""Verify that the given order of derivatives are valid.
+
+    Valid orders of derivatives must satisfy the following conditions:
+
+    - Convertible to a 1D numeric array
+    - The length must match the spatial dimension (``m``)
+    - Integer values (whole numbers only, round floats like 2.0 are accepted
+      and converted)
+    - Non-negative (all values are >=0, no NaN, no Inf)
+
+    Parameters
+    ----------
+    order : array_like
+        Order of derivative for each dimension. An order must be specified
+        for each spatial dimension. Non-integer values are accepted only
+        if they represent whole numbers.
+    spatial_dimension : int
+        Expected number of dimensions (must be positive).
+
+    Returns
+    -------
+    :class:`numpy:numpy.ndarray`
+        Validated order of derivatives as a 1D array of shape ``(m,)`` with
+        dtype ``INT_DTYPE``.
+
+    Raises
+    ------
+    InvalidDerivativeOrderError
+        If the specification violate any validation condition (see above).
+
+    Examples
+    --------
+    >>> verify_derivative_order(1, 1)  # Scalar, 1D
+    array([1])
+    >>> verify_derivative_order([1, 0, 1], 3)  # List as order, 3D
+    array([1, 0, 1])
+    >>> verify_derivative_order(np.array([1, 0, 2, 0]), 4)  # 4D
+    array([1, 0, 2, 0])
+    >>> verify_derivative_order([3, 2, 0], 2) # doctest: +NORMALIZE_WHITESPACE
+    Traceback (most recent call last):
+    ...
+    minterpy.utils.exceptions.InvalidDerivativeOrderError: Order length 3 does
+    not match spatial dimension 2. Order of derivative for each dimension must
+    be specified.
+    >>> verify_derivative_order([3.2, 2.0], 2) # doctest: +NORMALIZE_WHITESPACE
+    Traceback (most recent call last):
+    ...
+    minterpy.utils.exceptions.InvalidDerivativeOrderError: Order of derivatives
+    must be whole numbers. Invalid values: [3.2]
+    >>> verify_derivative_order([0, -1], 2) # doctest: +NORMALIZE_WHITESPACE
+    Traceback (most recent call last):
+    ...
+    minterpy.utils.exceptions.InvalidDerivativeOrderError: Order of
+    derivatives must be non-negative. Negative values at dimensions: [1];
+    Invalid values: [-1]
+    """
+    # Normalize input to 1D NumPy array
+    order = np.ravel(order)
+
+    # Validate length matches spatial dimension
+    if len(order) != spatial_dimension:
+        raise InvalidDerivativeOrderError(
+            f"Order length {len(order)} does not match spatial dimension "
+            f"{spatial_dimension}. Order of derivative for each dimension "
+            f"must be specified."
+        )
+
+    # Validate integer values (accept round floats)
+    round_mask = np.mod(order, 1) == 0
+    if not np.all(round_mask):
+        non_round_mask = ~round_mask
+        invalid_values = order[non_round_mask]
+        raise InvalidDerivativeOrderError(
+            f"Order of derivatives must be whole numbers. "
+            f"Invalid values: {invalid_values.tolist()}"
+        )
+
+    # Validate non-negative values
+    if np.any(order < 0):
+        negative_dims = np.where(order < 0)[0]
+        invalid_values = order[negative_dims]
+        raise InvalidDerivativeOrderError(
+            f"Order of derivatives must be non-negative. "
+            f"Negative values at dimensions: {negative_dims.tolist()}; "
+            f"Invalid values: {invalid_values.tolist()}"
+        )
+
+    # Convert to integer dtype
+    order = order.astype(INT_DTYPE)
+
+    return order
 
 
 def _add_custom_exception_message(

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1,0 +1,446 @@
+import numpy as np
+import pytest
+
+from minterpy import Domain
+from minterpy.utils.exceptions import InvalidDomainBoundsError
+
+INVALID_BOUNDS = [
+    {"type": "empty", "bounds": np.array([])},
+    {"type": "nan", "bounds": np.array([[1, np.nan], [2, 3]])},
+    {"type": "inf", "bounds": np.array([[1, 3], [2, np.inf]])},
+    {"type": "too_few", "bounds": np.array([1])},
+    {"type": "too_many", "bounds": np.array([1, 2, 3])},
+    {"type": "wrong_shape", "bounds": np.array([[1], [2]])},
+    {"type": "lower>upper", "bounds": np.array([3, 1])},
+    {"type": "lower==upper", "bounds": np.array([[1, 1], [2, 2], [3, 3]])},
+]
+
+
+# Invalid values (`val`)
+def _id_invalid_bounds(invalid_bounds):
+    return f"val={invalid_bounds['type']:>12}"
+
+
+@pytest.fixture(params=INVALID_BOUNDS, ids=_id_invalid_bounds)
+def invalid_bounds(request):
+    """Return invalid bounds fixture."""
+    return request.param["bounds"]
+
+
+@pytest.fixture
+def random_bounds_valid(SpatialDimension):
+    """Generate random valid bounds for testing."""
+    bounds = np.random.uniform(low=0, high=5, size=(SpatialDimension, 2))
+    bounds[:, 0] = -1 * bounds[:, 0]
+
+    return bounds
+
+
+@pytest.fixture
+def random_bounds_pair(SpatialDimension):
+    """Generate a pair of random valid bounds for testing."""
+    bounds_1 = np.random.uniform(low=0, high=5, size=(SpatialDimension, 2))
+    bounds_1[:, 0] = -1 * bounds_1[:, 0]
+
+    bounds_2 = np.random.uniform(low=0, high=5, size=(SpatialDimension, 2))
+    bounds_2[:, 0] = -1 * bounds_2[:, 0]
+
+    return bounds_1, bounds_2
+
+
+def generate_values_inbounds(random_bounds):
+    """Generate random valid values for testing."""
+    dim = len(random_bounds)
+    lb, ub = random_bounds[:, 0], random_bounds[:, 1]
+    bound_widths = ub - lb
+
+    return lb + np.random.rand(10, dim) * bound_widths
+
+
+def generate_values_outbounds(random_bounds):
+    """Generate random out of bounds values for testing."""
+    dim = len(random_bounds)
+    xx = np.empty((10, dim))
+    lb, ub = random_bounds[:, 0], random_bounds[:, 1]
+
+    idx = np.random.randint(0, 10)
+    for j in range(dim):
+        for i in range(idx):
+            xx[i, j] = lb[j] - np.random.rand()
+        for i in range(10 - idx):
+            xx[idx+i, j] = ub[j] + np.random.rand()
+
+    return xx
+
+class TestInit:
+    """All tests related to the default construction of Domain."""
+
+    def test_one_dimension(self):
+        """Test that a 1D domain is correctly initialized."""
+        bounds = np.array([-5, 5])
+        domain = Domain(bounds)
+
+        # Assertions
+        assert domain.spatial_dimension == 1
+        assert np.all(bounds == domain.bounds)
+
+    def test_invalid_bounds_smaller_upper(self, invalid_bounds):
+        """Test raising an exception for any invalid bounds."""
+
+        with pytest.raises(InvalidDomainBoundsError):
+            _ = Domain(invalid_bounds)
+
+
+class TestFactoryMethods:
+    """All tests related to the construction via factory methods."""
+
+    def test_uniform_domain(self, SpatialDimension):
+        """Test that a uniform domain is correctly initialized."""
+        upper_bound = np.random.uniform(0, 5)
+        lower_bound = -1 * upper_bound
+
+        domain = Domain.uniform(SpatialDimension, lower_bound, upper_bound)
+
+        # Assertions
+        assert domain.spatial_dimension == SpatialDimension
+        assert np.all(domain.bounds[:, 0] == lower_bound)
+        assert np.all(domain.bounds[:, 1] == upper_bound)
+
+    def test_normalized_domain(self, SpatialDimension):
+        """Test that a normalized domain is correctly initialized."""
+        domain = Domain.normalized(SpatialDimension)
+
+        # Assertions
+        assert domain.spatial_dimension == SpatialDimension
+        assert np.all(domain.bounds[:, 0] == -1.)
+        assert np.all(domain.bounds[:, 1] == 1.)
+
+
+class TestProperties:
+    """All tests related to the properties of Domain."""
+
+    def test_spatial_dimension(self, random_bounds_valid):
+        """Test the spatial dimension property."""
+        my_dom = Domain(random_bounds_valid)
+
+        # Assertion
+        assert my_dom.spatial_dimension == random_bounds_valid.shape[0]
+
+    def test_bounds(self, random_bounds_valid):
+        """Test the bounds property."""
+        my_dom = Domain(random_bounds_valid)
+
+        # Assertions
+        assert np.all(my_dom.bounds == random_bounds_valid)
+
+    def test_lower_bounds(self, random_bounds_valid):
+        """Test the lower bounds property."""
+        my_dom = Domain(random_bounds_valid)
+
+        # Assertion
+        assert np.all(my_dom.lower_bounds == random_bounds_valid[:, 0])
+
+    def test_upper_bounds(self, random_bounds_valid):
+        """Test the upper bounds property."""
+        my_dom = Domain(random_bounds_valid)
+
+        # Assertion
+        assert np.all(my_dom.upper_bounds == random_bounds_valid[:, 1])
+
+    def test_domain_widths(self, random_bounds_valid):
+        """Test the domain widths property."""
+        my_dom = Domain(random_bounds_valid)
+
+        # Assertion
+        diff_bounds = random_bounds_valid[:, 1] - random_bounds_valid[:, 0]
+        assert np.all(my_dom.domain_widths == diff_bounds)
+
+    def test_normalized(self, SpatialDimension):
+        """Test the normalized property for normalized domain."""
+        my_dom_1 = Domain.normalized(SpatialDimension)
+        my_dom_2 = Domain.uniform(SpatialDimension, -1, 1)
+        bounds = np.ones((SpatialDimension, 2))
+        bounds[:, 0] = -1
+        my_dom_3 = Domain(bounds)
+
+        # Assertions
+        assert my_dom_1.is_normalized
+        assert my_dom_2.is_normalized
+        assert my_dom_3.is_normalized
+
+    def test_not_normalized(self, random_bounds_valid):
+        """"Test the normalized property for non-normalized domain."""
+        my_dom = Domain(random_bounds_valid)
+
+        # Assertion
+        assert not my_dom.is_normalized
+
+
+class TestMapValues:
+    """All tests related to the mapping of values."""
+
+    def test_to_normalized_edges(self, random_bounds_valid):
+        """"Test the mapping of the edges to the normalized domain."""
+        my_dom = Domain(random_bounds_valid)
+
+        # Generate values at the edge of the domain
+        xx = np.c_[my_dom.lower_bounds, my_dom.upper_bounds].T
+        yy = my_dom.map_to_normalized(xx)
+
+        # Assertions
+        assert np.allclose(yy[0], -1.0)
+        assert np.allclose(yy[1], 1.0)
+
+    def test_from_normalized_edges(self, random_bounds_valid):
+        """"Test the mapping of the edges from the normalized domain."""
+        my_dom = Domain(random_bounds_valid)
+
+        # Generate values at the edge of the normalized domain
+        dim = my_dom.spatial_dimension
+        xx = np.c_[-1 * np.ones(dim), np.ones(dim)].T
+        yy = my_dom.map_from_normalized(xx)
+
+        # Assertions
+        assert np.allclose(yy[0], my_dom.lower_bounds)
+        assert np.allclose(yy[1], my_dom.upper_bounds)
+
+    def test_to_normalized_extrapolation(self, random_bounds_valid):
+        """Test that extrapolation to normalized domain is correctly handled."""
+        my_dom = Domain(random_bounds_valid)
+
+        # Generate out of bounds values in the original domain
+        xx = generate_values_outbounds(random_bounds_valid)
+        yy = my_dom.map_to_normalized(xx)
+
+        # Assertion
+        assert np.any(yy <= -1.) or np.any(yy >= 1.)
+
+    def test_from_normalized_extrapolation(self, random_bounds_valid):
+        """Test that extrapolation from normalized domain is correctly handled.
+        """
+        my_dom = Domain(random_bounds_valid)
+
+        # Generate out of bounds values in the normalized domain
+        bounds = np.ones((my_dom.spatial_dimension, 2))
+        bounds[:, 0] = -1
+        xx = generate_values_outbounds(bounds)
+        yy = my_dom.map_from_normalized(xx)
+
+        # Assertion
+        lb, ub = my_dom.lower_bounds, my_dom.upper_bounds
+        assert np.any(yy <= lb) or np.any(yy >= ub)
+
+    def test_to_normalized_valid(self, random_bounds_valid):
+        """Test transformation to the normalized domain with valid values."""
+        my_dom = Domain(random_bounds_valid)
+
+        # Generate random valid input values
+        xx = generate_values_inbounds(random_bounds_valid)
+        # All the same for valid input values
+        yy_1 = my_dom.map_to_normalized(xx)
+        yy_2 = my_dom.map_to_normalized(xx, validate=True)
+        yy_3 = my_dom.map_to_normalized(xx, validate=False)
+
+        # Assertion
+        assert np.all(yy_1 >= -1.) and np.all(yy_1 <= 1.)
+        assert np.all(yy_2 >= -1.) and np.all(yy_2 <= 1.)
+        assert np.all(yy_3 >= -1.) and np.all(yy_3 <= 1.)
+
+    def test_to_normalized_invalid(self, random_bounds_valid):
+        """Test transformation to the normalized domain with invalid values."""
+        my_dom = Domain(random_bounds_valid)
+
+        # Generate random invalid input values
+        xx = generate_values_outbounds(random_bounds_valid)
+
+        with pytest.raises(ValueError):
+            _ = my_dom.map_to_normalized(xx, validate=True)
+
+    def test_from_normalized_valid(self, random_bounds_valid):
+        """Test transformation from the normalized domain with valid values."""
+        my_dom = Domain(random_bounds_valid)
+
+        # Generate random valid input values in the normalized domain
+        xx = -1 + 2 * np.random.rand(10, my_dom.spatial_dimension)
+        # All the same for valid input values
+        yy_1 = my_dom.map_from_normalized(xx)
+        yy_2 = my_dom.map_from_normalized(xx, validate=True)
+        yy_3 = my_dom.map_from_normalized(xx, validate=False)
+
+        # Assertion
+        lb, ub = my_dom.lower_bounds, my_dom.upper_bounds
+        assert np.all(yy_1 >= lb) and np.all(yy_1 <= ub)
+        assert np.all(yy_2 >= lb) and np.all(yy_2 <= ub)
+        assert np.all(yy_3 >= lb) and np.all(yy_3 <= ub)
+
+    def test_from_normalized_validation_invalid(self, random_bounds_valid):
+        """Test transformation from the normalized domain with invalid values.
+        """
+        my_dom = Domain(random_bounds_valid)
+
+        # Generate random invalid input values in the normalized domain
+        xx = -10 + 3 * np.random.rand(10, my_dom.spatial_dimension)
+
+        # Assertion
+        with pytest.raises(ValueError):
+            _ = my_dom.map_from_normalized(xx, validate=True)
+
+    def test_from_and_to(self, random_bounds_valid):
+        """Test that values are correctly mapped from and to normalized."""
+        my_dom = Domain(random_bounds_valid)
+
+        # Generate random valid input values in the normalized domain
+        xx_1 = -1 + 2 * np.random.rand(10, my_dom.spatial_dimension)
+        yy = my_dom.map_from_normalized(xx_1)
+        xx_2 = my_dom.map_to_normalized(yy)
+
+        # Assertions
+        assert np.allclose(xx_1, xx_2)
+
+    def test_to_and_from(self, random_bounds_valid):
+        """Test that values are correctly mapped to and from normalized."""
+        my_dom = Domain(random_bounds_valid)
+
+        # Generate random valid input values in the original domain
+        xx_1 = generate_values_inbounds(random_bounds_valid)
+        yy = my_dom.map_to_normalized(xx_1)
+        xx_2 = my_dom.map_from_normalized(yy)
+
+        # Assertions
+        assert np.allclose(xx_1, xx_2)
+
+
+class TestScalingFactor:
+    """All tests related to the scaling factor."""
+
+    def test_integration(self, random_bounds_valid):
+        """Test the integration scaling factor."""
+        my_dom = Domain(random_bounds_valid)
+        diff_bounds = random_bounds_valid[:, 1] - random_bounds_valid[:, 0]
+
+        assert np.isclose(
+            my_dom.get_int_factor(),
+            np.prod(diff_bounds) / 2**my_dom.spatial_dimension,
+        )
+
+    def test_integration_normalized(self, SpatialDimension):
+        """Test the integration scaling factor for normalized domain."""
+        dom = Domain.normalized(SpatialDimension)
+
+        assert np.isclose(dom.get_int_factor(), 1.)
+
+    def test_diff_zero_order(self, random_bounds_valid):
+        """Test the differentiation scaling factor for 0th-order derivative."""
+        my_dom = Domain(random_bounds_valid)
+
+        # Assertions
+        expected = 1.0  # Always 1.0
+        dim = my_dom.spatial_dimension
+        assert np.isclose(
+            my_dom.get_diff_factor(np.zeros(dim, dtype=int)),
+            expected,
+        )
+
+    def test_diff_normalized(self, SpatialDimension):
+        """Test the differentiation scaling factor in the normalized domain."""
+        my_dom = Domain.normalized(SpatialDimension)
+
+        # Assertion
+        expected = 1.0  # Always 1.0
+        order = np.random.randint(0, 5, size=(SpatialDimension,))
+        assert np.isclose(my_dom.get_diff_factor(order), expected)
+
+
+class TestEquality:
+    """All tests related to equality check."""
+
+    def test_equal(self, random_bounds_valid):
+        """Test strict equality of values between two instances."""
+        my_dom_1 = Domain(random_bounds_valid)
+        my_dom_2 = Domain(random_bounds_valid)
+
+        # Assertions
+        assert my_dom_1 is not my_dom_2
+        assert my_dom_2 is not my_dom_1
+        assert my_dom_1 == my_dom_2
+        assert my_dom_2 == my_dom_1
+
+    def test_not_equal_bounds(self, random_bounds_pair):
+        """Test strict inequality of bounds between two instances."""
+        bounds_1, bounds_2 = random_bounds_pair
+        my_dom_1 = Domain(bounds_1)
+        my_dom_2 = Domain(bounds_2)
+
+        # Assertions
+        assert my_dom_1 is not my_dom_2
+        assert my_dom_2 is not my_dom_1
+        assert my_dom_1 != my_dom_2
+        assert my_dom_2 != my_dom_1
+
+    def test_not_equal_dimensions(self, random_bounds_valid):
+        """Test strict inequality of dimensions between two instances."""
+        bounds_1 = random_bounds_valid
+        bounds_2 = np.vstack([bounds_1, bounds_1[-1]])
+
+        my_dom_1 = Domain(bounds_1)
+        my_dom_2 = Domain(bounds_2)
+
+        # Assertions
+        assert my_dom_1 is not my_dom_2
+        assert my_dom_2 is not my_dom_1
+        assert my_dom_1 != my_dom_2
+        assert my_dom_2 != my_dom_1
+
+
+class TestPartialMatching:
+    """All tests related to partial matching."""
+
+    def test_partially_matched(self, random_bounds_valid):
+        """Test partially matched domain."""
+        bounds_1 = random_bounds_valid
+        bounds_2 = np.vstack([bounds_1, bounds_1[-1]])
+
+        my_dom_1 = Domain(bounds_1)
+        my_dom_2 = Domain(bounds_2)
+
+        # Assertions (symmetric)
+        assert my_dom_1.partial_matching(my_dom_2)
+        assert my_dom_2.partial_matching(my_dom_1)
+
+    def test_no_partially_matched(self, random_bounds_pair):
+        """Test no partially matched domain."""
+        bounds_1, bounds_2 = random_bounds_pair
+
+        my_dom_1 = Domain(bounds_1)
+        if len(bounds_2) > 1:
+            my_dom_2 = Domain(bounds_2[:-1])
+        else:
+            my_dom_2 = Domain(bounds_2)
+
+        # Assertions (symmetric)
+        assert not my_dom_1.partial_matching(my_dom_2)
+        assert not my_dom_2.partial_matching(my_dom_1)
+
+
+class TestContains:
+    """All tests related to the contains check."""
+
+    def test_contained(self, random_bounds_valid):
+        """Test containment of sample inside the bounds."""
+        my_dom = Domain(random_bounds_valid)
+
+        # Generate random valid input values in the original domain
+        xx = generate_values_inbounds(random_bounds_valid)
+
+        # Assertion
+        assert np.all(my_dom.contains(xx))
+
+    def test_not_contained(self, random_bounds_valid):
+        """Test containment of sample outside the bounds."""
+        my_dom = Domain(random_bounds_valid)
+
+        # Generate input values outside the original bound
+        xx = generate_values_outbounds(random_bounds_valid)
+
+        # Assertion
+        assert not np.any(my_dom.contains(xx))


### PR DESCRIPTION
Add Domain class to handle affine coordinate transformations between user-defined rectangular domains and the normalized domain $[-1,1]^m$.

Features:

- Affine transformations: `map_to_normalized()`, `map_from_normalized()`
- Factory methods: `Domain.uniform()`, `Domain.normalized()`
- Scaling factors: `get_diff_factor()` (chain rule), `get_int_factor()` (Jacobian)
- Domain utilities: `contains()`, `partial_matching()`, `is_normalized`
- Optional validation with validate parameter

Implementation notes:

- Uses "normalized" terminology instead of "canonical" to avoid confusion
- Comprehensive test suite with 35+ tests across 9 test classes

Also adds:

- `verify_domain_bounds()` utility function for input validation
- `InvalidDomainBoundsError` as a new custom exception derived from `ValueError`

This PR should resolve Issue #51 and part of resolving Issue #50 (all changes related to that issue is staged in `dev-50` branch).