### PR TITLE
Add union operator and expand_dim method to Domain class

### DIFF
--- a/src/minterpy/core/domain.py
+++ b/src/minterpy/core/domain.py
@@ -15,8 +15,11 @@ affine applied to each dimension separately.
 """
 import numpy as np
 
+from typing import Union
+
 from minterpy.global_settings import FLOAT_DTYPE
 from minterpy.utils.verification import verify_domain_bounds
+from minterpy.utils.exceptions import DomainMismatchError
 
 __all__ = ["Domain"]
 
@@ -293,6 +296,68 @@ class Domain:
                 & np.all(xx <= self.upper_bounds, axis=1)
         )
 
+    def expand_dim(self, target: Union[int, "Domain"]) -> "Domain":
+        """Expand the dimension of the domain.
+
+        Parameters
+        ----------
+        target : Union[int, Domain]
+            The target dimension to expand to. If an integer, it specifies
+            the new dimension. If a Domain instance, it specifies the domain
+            whose dimension to expand to.
+
+        Returns
+        -------
+        Domain
+            A new instance of the :class:`Domain` class with expanded
+            dimension.
+
+        Raises
+        ------
+        ValueError
+            If the target dimension is smaller than the current dimension or
+            an expansion to a target integer is attempted for an unnormalized
+            domain.
+        DomainMismatchError
+            If the target domain does not match the current domain.
+        TypeError
+            If the target is not an instance of Domain or int.
+        """
+        if isinstance(target, int):
+            if target < self.spatial_dimension:
+                raise ValueError(
+                    f"Target dimension {target} cannot be smaller than "
+                    f"the current dimension {self.spatial_dimension}"
+                )
+
+            if not self.is_normalized:
+                raise ValueError(
+                    "Un-normalized domain cannot be expanded due to ambigous "
+                    "bounds for the extra dimension."
+                )
+
+            return self.__class__.normalized(target)
+
+        if isinstance(target, Domain):
+            if not self.partial_matching(target):
+                raise DomainMismatchError(
+                    "Target domain does not match the current domain"
+                )
+
+            if target.spatial_dimension < self.spatial_dimension:
+                raise ValueError(
+                    f"Target dimension {target.spatial_dimension} cannot be "
+                    "smaller than the current dimension "
+                    f"{self.spatial_dimension}"
+                )
+
+            return self.__class__(target.bounds.copy())
+
+        raise TypeError(
+            "Target domain must be an instance of Domain or int, "
+            f"got {type(target)} instead"
+        )
+
 
     # --- Dunder methods
     def __eq__(self, other: "Domain") -> bool:
@@ -313,7 +378,36 @@ class Domain:
             ``True`` if the two instances are equal in value,
             ``False`` otherwise.
         """
-        return (
-            self.spatial_dimension == other.spatial_dimension and
-            np.all(self.bounds == other.bounds)
-        )
+        if self.spatial_dimension != other.spatial_dimension:
+            return False
+
+        return self.partial_matching(other)
+
+
+    def __or__(self, other: "Domain") -> "Domain":
+        """Combine two instances of Domain via the ``|`` operator.
+
+        Two instances of Domain may be combined via the ``|`` operator if they
+        are partially matched.
+
+        Parameters
+        ----------
+        other : Domain
+            An instance of :class:`Domain` that is to be combined with the
+            the current instance.
+
+        Returns
+        -------
+        Domain
+            A new instance of :class:`Domain` that is the result of the
+            combination of the two instances.
+
+        Raises
+        ------
+        DomainMismatchError
+            If the two domains are not partially matched.
+        """
+        if self.spatial_dimension > other.spatial_dimension:
+            return other.expand_dim(self)
+
+        return self.expand_dim(other)

--- a/src/minterpy/utils/exceptions.py
+++ b/src/minterpy/utils/exceptions.py
@@ -10,3 +10,7 @@ class InvalidDomainBoundsError(ValueError):
 class InvalidDerivativeOrderError(ValueError):
     """Raised when order of derivatives specification is invalid."""
     pass
+
+
+class DomainMismatchError(ValueError):
+    """Raised when two instances of Domains do not match."""

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -2,7 +2,10 @@ import numpy as np
 import pytest
 
 from minterpy import Domain
-from minterpy.utils.exceptions import InvalidDomainBoundsError
+from minterpy.utils.exceptions import (
+    DomainMismatchError,
+    InvalidDomainBoundsError,
+)
 
 INVALID_BOUNDS = [
     {"type": "empty", "bounds": np.array([])},
@@ -444,3 +447,158 @@ class TestContains:
 
         # Assertion
         assert not np.any(my_dom.contains(xx))
+
+
+class TestUnion:
+    """All tests related to the union operation."""
+
+    def test_identical(self, random_bounds_valid):
+        """Test union of identical instances."""
+        my_dom_1 = Domain(random_bounds_valid)
+
+        my_dom_2 = my_dom_1 | my_dom_1
+
+        # Assertions
+        assert my_dom_1 == my_dom_2
+        assert my_dom_1 is not my_dom_2
+
+    def test_equal(self, random_bounds_valid):
+        """Test union of equal instances."""
+        my_dom_1 = Domain(random_bounds_valid)
+        my_dom_2 = Domain(random_bounds_valid)
+
+        my_dom_3 = my_dom_1 | my_dom_2
+        my_dom_4 = my_dom_2 | my_dom_1
+
+        # Assertions
+        assert my_dom_3 == my_dom_4
+        assert my_dom_3 is not my_dom_4
+
+    def test_expansion(self, random_bounds_valid):
+        """Test union of an instance with a higher dimension."""
+        bounds_1 = random_bounds_valid
+        bounds_2 = np.vstack([bounds_1, bounds_1[-1]])
+
+        my_dom_1 = Domain(bounds_1)
+        my_dom_2 = Domain(bounds_2)
+        my_dom_3 = my_dom_1 | my_dom_2
+        my_dom_4 = my_dom_2 | my_dom_1
+
+        # Assertions
+        assert my_dom_2 == my_dom_3
+        assert my_dom_2 == my_dom_4
+
+    def test_chaining(self, random_bounds_valid):
+        """Test union of three instances."""
+        bounds_1 = random_bounds_valid
+        bounds_2 = np.vstack([bounds_1, bounds_1[-1]])
+        bounds_3 = np.vstack([bounds_2, bounds_2[-1]])
+
+        my_dom_1 = Domain(bounds_1)
+        my_dom_2 = Domain(bounds_2)
+        my_dom_3 = Domain(bounds_3)
+
+        # Assertions
+        assert my_dom_3 == my_dom_1 | my_dom_2 | my_dom_3
+        assert my_dom_3 == my_dom_2 | my_dom_3 | my_dom_1
+        assert my_dom_3 == my_dom_3 | my_dom_2 | my_dom_1
+
+    def test_invalid(self, random_bounds_pair):
+        """Test union of instances with mismatching dimensions."""
+        bounds_1, bounds_2 = random_bounds_pair
+        my_dom_1 = Domain(bounds_1)
+        my_dom_2 = Domain(bounds_2)
+
+        with pytest.raises(DomainMismatchError):
+            _ = my_dom_1 | my_dom_2
+
+
+class TestExpandDim:
+    """All tests related to the expansion of the domain."""
+
+    def test_to_target_int_normalized(self, SpatialDimension):
+        """Test expanding the dimension to an integer target dimension."""
+        my_dom_1 = Domain.normalized(SpatialDimension)
+
+        my_dom_2 = my_dom_1.expand_dim(SpatialDimension + 1)
+
+        # Assertions
+        assert my_dom_1 is not my_dom_2
+        assert my_dom_1 != my_dom_2
+        assert my_dom_2 == Domain.normalized(SpatialDimension + 1)
+
+    def test_to_target_int_contraction(self, SpatialDimension):
+        """Test contracting the dimension to an integer target dimension."""
+        my_dom = Domain.normalized(SpatialDimension)
+
+        with pytest.raises(ValueError):
+            _ = my_dom.expand_dim(SpatialDimension - 1)
+
+    def test_to_target_int_unnormalized(self, random_bounds_valid):
+        """Test expanding the dimension to an integer target dimension."""
+        my_dom = Domain(random_bounds_valid)
+
+        with pytest.raises(ValueError):
+            _ = my_dom.expand_dim(my_dom.spatial_dimension + 1)
+
+    def test_to_target_domain_identical(self, random_bounds_valid):
+        """Test expanding the dimension to the same domain."""
+        my_dom = Domain(random_bounds_valid)
+
+        # Assertions
+        assert my_dom.expand_dim(my_dom) is not my_dom
+        assert my_dom.expand_dim(my_dom) == my_dom
+
+    def test_to_target_domain_equal(self, random_bounds_valid):
+        """Test expanding the dimension to a domain with the same bounds."""
+        my_dom_1 = Domain(random_bounds_valid)
+        my_dom_2 = Domain(random_bounds_valid)
+
+        # Assertions
+        assert my_dom_1.expand_dim(my_dom_2) is not my_dom_1
+        assert my_dom_2.expand_dim(my_dom_1) is not my_dom_2
+        assert my_dom_1.expand_dim(my_dom_2) == my_dom_1
+        assert my_dom_2.expand_dim(my_dom_1) == my_dom_2
+
+    def test_to_target_domain_expansion(self, random_bounds_valid):
+        """Test expanding the dimension to a domain with a higher dimension."""
+        bounds_1 = random_bounds_valid
+        bounds_2 = np.vstack([bounds_1, bounds_1[-1]])
+
+        my_dom_1 = Domain(bounds_1)
+        my_dom_2 = Domain(bounds_2)
+
+        # Assertions
+        assert my_dom_1.expand_dim(my_dom_2) is not my_dom_1
+        assert my_dom_1.expand_dim(my_dom_2) is not my_dom_2
+        assert my_dom_1.expand_dim(my_dom_2) == my_dom_2
+
+    def test_to_target_domain_contraction(self, random_bounds_valid):
+        """Test expanding the dimension to a domain with a lower dimension."""
+        bounds_1 = random_bounds_valid
+        bounds_1 = np.vstack([bounds_1, bounds_1[-1]])
+        bounds_2 = random_bounds_valid
+
+
+        my_dom_1 = Domain(bounds_1)
+        my_dom_2 = Domain(bounds_2)
+
+        # Assertions
+        with pytest.raises(ValueError):
+            _ = my_dom_1.expand_dim(my_dom_2)
+
+    def test_to_target_domain_mismatch(self, random_bounds_pair):
+        """Test that an exception is raised for mismatching dimensions."""
+        bounds_1, bounds_2 = random_bounds_pair
+        my_dom_1 = Domain(bounds_1)
+        my_dom_2 = Domain(bounds_2)
+
+        with pytest.raises(DomainMismatchError):
+            _ = my_dom_1.expand_dim(my_dom_2)
+
+    def test_to_target_domain_invalid_type(self, random_bounds_valid):
+        """Test that an exception is raised for invalid target domain."""
+        my_dom = Domain(random_bounds_valid)
+
+        with pytest.raises(TypeError):
+            _ = my_dom.expand_dim([1, 2, 3])


### PR DESCRIPTION
Implement `__or__` dunder method to combine domains with different dimensions via the | operator. Add expand_dim() method to support dimension expansion with either integer or Domain targets.

- The implementation of __or__ is delegated to expand_dim()
- Add expand_dim(int) for expanding normalized domains
- Add expand_dim(Domain) for expanding to match target domain
- Raise (a new) DomainMismatchError when domains not partially matched
- Raise ValueError for invalid dimension targets
- Add comprehensive test coverage for both operations

This commit should resolve Issue #62.