### PR TITLE
Integrate Domain class with Grid

### DIFF
--- a/src/minterpy/core/grid.py
+++ b/src/minterpy/core/grid.py
@@ -17,6 +17,36 @@ where the function to be interpolated is evaluated.
 More detailed background information can be found in
 :doc:`/fundamentals/interpolation-at-unisolvent-nodes`.
 
+Generating Points Convention
+-----------------------------
+
+The generating points are stored as a two-dimensional array of shape
+``(n + 1, m)``:
+
+- **Columns** represent spatial dimensions: each column contains the
+  one-dimensional interpolation nodes for that specific dimension
+- **Rows** represent polynomial degrees: row ``i`` contains nodes for
+  polynomial degree ``i`` (from degree 0 to degree ``n``)
+
+**Important**: Currently, generating points must be defined in the normalized
+domain :math:`[-1, 1]^m`. When a custom user domain is specified,
+the Grid handles transformation automatically during function evaluation.
+
+Example structure for a 2D grid with maximum degree 3::
+
+    generating_points = [
+        [x0_dim1, x0_dim2],  # Degree 0 nodes
+        [x1_dim1, x1_dim2],  # Degree 1 nodes
+        [x2_dim1, x2_dim2],  # Degree 2 nodes
+        [x3_dim1, x3_dim2],  # Degree 3 nodes
+    ]
+    # All values must be in [-1, 1]
+
+The generating function, when provided, produces this array structure.
+Different generating function (e.g., Chebyshev-Lobatto, equidistant, Leja)
+creates different node distributions within :math:`[-1, 1]`, each with distinct
+approximation properties.
+
 How-To Guides
 =============
 
@@ -28,13 +58,14 @@ demonstrating their usages and features.
 
 """
 from copy import copy, deepcopy
-from typing import Callable, Optional, Union
+from typing import Callable, Optional, Union, Tuple
 
 import numpy as np
 
 from minterpy.global_settings import ARRAY, INT_DTYPE
 from minterpy.gen_points import GENERATING_FUNCTIONS, gen_points_from_values
 
+from minterpy.core.domain import Domain
 from minterpy.core.multi_index import MultiIndexSet
 from minterpy.core.tree import MultiIndexTree
 from minterpy.utils.arrays import is_unique
@@ -52,14 +83,6 @@ DEFAULT_FUN = "chebyshev"
 
 # Type alias
 GEN_FUNCTION = Callable[[int, int], np.ndarray]
-
-
-def _gen_unisolvent_nodes(multi_index, generating_points):
-    """
-    .. todo::
-        - document this function but ship it to utils first.
-    """
-    return np.take_along_axis(generating_points, multi_index.exponents, axis=0)
 
 
 # TODO implement comparison operations based on multi index comparison operations and the generating values used
@@ -93,6 +116,10 @@ class Grid:
         are created from the default generating function. If specified,
         then the points must be consistent with any non-``None`` generating
         function.
+    domain : Domain, optional
+        The domain of the interpolation grid. This parameter is optional.
+        If not specified, a normalized domain in the hypercube of
+        :math:`[-1, 1]^m` is created.
 
     Notes
     -----
@@ -101,6 +128,11 @@ class Grid:
       of the multi-index set of polynomial exponents and the spatial dimension
       (``m``). Furthermore, it must return an array of shape ``(n + 1, m)``
       whose values are unique per column.
+    - Generating points array has shape ``(n + 1, m)`` where columns
+      represent spatial dimensions and rows represent polynomial degrees.
+      All values must be in the normalized domain :math:`[-1, 1]^m`.
+      Different generating functions create different node distributions within
+      this normalized space.
     - The multi-index set to construct a :class:`Grid` instance may not be
       downward-closed. However, building a :class:`.MultiIndexTree` used
       in the transformation between polynomials in the Newton and Lagrange
@@ -114,6 +146,7 @@ class Grid:
         multi_index: MultiIndexSet,
         generating_function: Optional[Union[GEN_FUNCTION, str]] = None,
         generating_points: Optional[np.ndarray] = None,
+        domain: Optional[Domain] = None,
     ):
 
         # --- Arguments processing
@@ -142,6 +175,12 @@ class Grid:
         self._generating_points = generating_points
         self._verify_generating_points()
 
+        # Process and assign the domain
+        if domain is None:
+            domain = Domain.normalized(self.multi_index.spatial_dimension)
+
+        self._domain = _process_domain(domain, multi_index)
+
         # --- Post-assignment verifications
 
         # Verify the maximum exponent
@@ -164,6 +203,7 @@ class Grid:
         lp_degree: float,
         generating_function: Optional[Union[GEN_FUNCTION, str]] = None,
         generating_points: Optional[np.ndarray] = None,
+        domain: Optional[Domain] = None,
     ):
         r"""Create an instance of Grid with a complete multi-index set.
 
@@ -206,6 +246,10 @@ class Grid:
             the generating points are created from the default generating
             function. If specified, then the points must be consistent
             with any non-``None`` generating function.
+        domain : Domain, optional
+            The domain of the interpolation grid. This parameter is optional.
+            If not specified, a normalized domain in the hypercube of
+            :math:`[-1, 1]^m` is created.
 
         Returns
         -------
@@ -222,13 +266,14 @@ class Grid:
         )
 
         # Create an instance of Grid
-        return cls(mi, generating_function, generating_points)
+        return cls(mi, generating_function, generating_points, domain=domain)
 
     @classmethod
     def from_function(
         cls,
         multi_index: MultiIndexSet,
         generating_function: Union[GEN_FUNCTION, str],
+        domain: Optional[Domain] = None,
     ) -> "Grid":
         """Create an instance of Grid with a given generating function.
 
@@ -246,6 +291,10 @@ class Grid:
             and ``m`` is the spatial dimension.
             Alternatively, a string as a key to dictionary of built-in
             generating functions may be specified.
+        domain : Domain, optional
+            The domain of the interpolation grid. This parameter is optional.
+            If not specified, a normalized domain in the hypercube of
+            :math:`[-1, 1]^m` is created.
 
         Returns
         -------
@@ -253,13 +302,18 @@ class Grid:
             A new instance of the `Grid` class initialized with the given
             generating function.
         """
-        return cls(multi_index, generating_function=generating_function)
+        return cls(
+            multi_index,
+            generating_function=generating_function,
+            domain=domain,
+        )
 
     @classmethod
     def from_points(
         cls,
         multi_index: MultiIndexSet,
         generating_points: np.ndarray,
+        domain: Optional[Domain] = None,
     ) -> "Grid":
         """Create an instance of Grid from an array of generating points.
 
@@ -275,6 +329,10 @@ class Grid:
             where ``n`` is the maximum polynomial degree in all dimensions
             (i.e., the maximum exponent) and ``m`` is the spatial dimension.
             The values in each column must be unique.
+        domain : Domain, optional
+            The domain of the interpolation grid. This parameter is optional.
+            If not specified, a normalized domain in the hypercube of
+            :math:`[-1, 1]^m` is created.
 
         Returns
         -------
@@ -282,13 +340,18 @@ class Grid:
             A new instance of the `Grid` class initialized
             with the given multi-index set and generating points.
         """
-        return cls(multi_index, generating_points=generating_points)
+        return cls(
+            multi_index,
+            generating_points=generating_points,
+            domain=domain,
+        )
 
     @classmethod
     def from_value_set(
         cls,
         multi_index: MultiIndexSet,
         generating_values: np.ndarray,
+        domain: Optional[Domain] = None,
     ):
         """Create an instance of Grid from an array of generating values.
 
@@ -304,6 +367,10 @@ class Grid:
             a one-dimensional array of floats of length ``(n + 1, )``
             where ``n`` is the maximum exponent of the multi-index set.
             The values in the array must be unique.
+        domain : Domain, optional
+            The domain of the interpolation grid. This parameter is optional.
+            If not specified, a normalized domain in the hypercube of
+            :math:`[-1, 1]^m` is created.
 
         Returns
         -------
@@ -331,7 +398,11 @@ class Grid:
             spatial_dimension,
         )
 
-        return cls(multi_index, generating_points=generating_points)
+        return cls(
+            multi_index,
+            generating_points=generating_points,
+            domain=domain,
+        )
 
     # --- Properties
     @property
@@ -384,6 +455,19 @@ class Grid:
         return self._generating_points
 
     @property
+    def domain(self) -> Domain:
+        """The domain associated with the Grid.
+
+        The domain represents the rectangular bounds of the Grid.
+
+        Returns
+        -------
+        Domain
+            The domain of the interpolation grid.
+        """
+        return self._domain
+
+    @property
     def max_exponent(self) -> int:
         """The maximum exponent of the interpolation grid.
 
@@ -397,18 +481,26 @@ class Grid:
 
     @property
     def unisolvent_nodes(self) -> np.ndarray:
-        """The array of unisolvent nodes.
+        """The array of unisolvent nodes in the normalized domain.
 
-        For a definition of unisolvent nodes, see
-        :doc:`/fundamentals/unisolvence`
-        in the docs.
+        The unisolvent nodes are provided in the normalized domain
+        :math:`[-1, 1]^m`.
+
+        For a definition of unisolvent nodes,
+        see :doc:`/fundamentals/unisolvence` in the docs.
 
         Returns
         -------
         :class:`numpy:numpy.ndarray`
-            The unisolvent nodes as a two-dimensional array of floats.
-            The shape of the array is ``(N, m)`` where ``N`` is the number of
-            elements in the multi-index set and ``m`` is the spatial dimension.
+            The unisolvent nodes in [-1, 1]^m as a two-dimensional array
+            of floats. The shape of the array is ``(N, m)``
+            where ``N`` is the number of elements in the multi-index set
+            and ``m`` is the spatial dimension.
+
+        Notes
+        -----
+        - When evaluating functions via ``grid(func)``,
+          the nodes are automatically transformed to the user-defined domain.
         """
         if self._unisolvent_nodes is None:  # lazy evaluation
             self._unisolvent_nodes = _gen_unisolvent_nodes(
@@ -442,18 +534,6 @@ class Grid:
         if self._tree is None:  # lazy evaluation
             self._tree = MultiIndexTree(self)
         return self._tree
-
-    @property
-    def has_generating_function(self) -> bool:
-        """Return ``True`` if the instance has a generating function.
-
-        Returns
-        -------
-        bool
-            ``True`` if the instance has a generating function assigned to it,
-            and ``False`` otherwise.
-        """
-        return self.generating_function is not None
 
     @property
     def is_complete(self) -> bool:
@@ -506,66 +586,142 @@ class Grid:
 
         return self._new_instance(mi_added)
 
-    def expand_dim(self, target_dimension: Union[int, "Grid"]) -> "Grid":
-        """Expand the dimension of the Grid.
+    def expand_dim(self, target: Union[int, "Grid"]) -> "Grid":
+        """Expand the dimension of the Grid to a target dimension or Grid.
+
+        This method creates a new Grid with a higher spatial dimension by
+        expanding both the underlying multi-index set and the domain.
+        The expansion can target either a specific integer dimension
+        or match the dimension of another (compatible) Grid instance.
 
         Parameters
         ----------
-        target_dimension : Union[Grid, int]
-            The new spatial dimension. It must be larger than or equal
-            to the current dimension of the Grid. Alternatively,
-            another instance of Grid whose dimension is higher can also
-            be specified as a target dimension.
+        target : Union[Grid, int]
+            The target for for dimension expansion:
+
+            - If int: The new spatial dimension (must be >= current dimension).
+              For non-normalized domains, expansion to an integer is not
+              allowed.
+            - If Grid: Another Grid instance whose dimension to match.
+              The grids must have compatible generating functions or points.
 
         Returns
         -------
         Grid
-            The Grid with expanded dimension.
+            A new Grid instance with expanded dimension, containing:
+
+            - Expanded multi-index set
+            - Expanded domain
+            - Compatible generating function or points
 
         Raises
         ------
         ValueError
-            If an instance is expanded to a dimension that cannot be supported
-            either by the available generating function or generating points.
-            If the target dimension is a `Grid`, the exception is raised
-            when there are inconsistencies in either generating function
-            or points.
+            If the target dimension is smaller than the current dimension,
+            if expanding a non-normalized domain to an integer dimension,
+            if the generating points cannot accommodate the target dimension,
+            or if the Grid is not compatible with the target Grid.
         """
         # Expand the dimension to the target Grid instance
-        if isinstance(target_dimension, Grid):
-            return _expand_dim_to_target_grid(self, target_dimension)
+        if isinstance(target, Grid):
+           return self._expand_to_grid(target)
 
-        # Expand to the target dimension
-        return _expand_dim_to_target_dim(self, target_dimension)
+        return self._expand_to_dimension(target)
 
-    def is_compatible(self, other: "Grid") -> bool:
-        """Return ``True`` if the instance is compatible with another.
+    def has_compatible_gen_function(self, other: "Grid") -> bool:
+        """Check if two grids have a compatible generating function.
 
-        Two grids are compatible if they have the same generating function
-        (if exists) and the generating points up to a common dimension.
+        Two grids have a compatible generating function if each has
+        a generating function and they are an identical function.
 
         Parameters
         ----------
         other : Grid
-            The other instance to check its compatibility with the current
-            instance.
+            Another Grid instance to check compatibility with.
 
         Returns
         -------
         bool
-            ``True`` if the current instance is compatible with the given
-            instance; ``False`` otherwise.
+            ``True`` if the generating functions are compatible,
+            ``False`` otherwise.
         """
-        if _have_gen_functions(self, other):
-            # Check if the Grid instances have compatible generating functions
-            if not _have_compatible_gen_functions(self, other):
-                return False
-
-        # Check if the Grid instances have compatible generating points
-        if _have_compatible_gen_points(self, other):
-            return True
+        if self._has_generating_function and other._has_generating_function:
+            # Check if the grid instances have compatible generating functions
+            if self.generating_function == other.generating_function:
+                return True
 
         return False
+
+    def has_compatible_gen_points(self, other: "Grid") -> bool:
+        """Check if two grids have compatible generating points.
+
+        Two grids have compatible generating points if their generating point
+        arrays match in the common dimensions (columns) and common degrees
+        (rows). Compatibility is checked by comparing the overlapping subarray.
+
+        Parameters
+        ----------
+        other : Grid
+            Another Grid instance to check compatibility with.
+
+        Returns
+        -------
+        bool
+            ``True`` if the generating points are compatible in their common
+            dimensions and degrees, ``False`` otherwise.
+
+        Notes
+        -----
+        - Compatibility is checked only for the intersection of dimensions
+          and degrees
+        - For example, a grid with 3D generating points can be compatible with
+          a 2D grid if their first 2 dimensions match; or a grid with degree 5
+          can be compatible with degree 3 if the first 4 rows (degrees 0-3)
+          match
+        """
+        # Find common dimensions and degrees to compare
+        common_dim = min(self.spatial_dimension, other.spatial_dimension)
+        common_deg = min(
+            self.generating_points.shape[0],
+            other.generating_points.shape[0]
+        )
+
+        # Extract overlapping subarrays
+        gen_points_self = self.generating_points[:common_deg, :common_dim]
+        gen_points_other = other.generating_points[:common_deg, :common_dim]
+
+        # Check if they match
+        return np.array_equal(gen_points_self, gen_points_other)
+
+    def is_compatible(self, other: "Grid") -> bool:
+        """Check if two instances of Grid are compatible.
+
+        Two instances of Grid are compatible if they have:
+
+        - The same generating function (when both have one), OR
+        - Compatible generating points (matching values in common dimensions,
+          i.e., columns and common degrees, i.e., rows)
+
+
+        Parameters
+        ----------
+        other : Grid
+            Another Grid instance to check compatibility with.
+
+        Returns
+        -------
+        bool
+            ``True`` if the generating data is compatible, ``False`` otherwise.
+
+        Notes
+        -----
+        - This method checks ONLY the compatibility of the underlying
+          generating functions or points of the two instances of Grid.
+        """
+        return (
+            self.has_compatible_gen_function(other) or
+            self.has_compatible_gen_points(other)
+        )
 
     def make_complete(self) -> "Grid":
         """Complete the underlying multi-index set of the `Grid` instance.
@@ -615,121 +771,97 @@ class Grid:
 
         return self._new_instance(mi_downward_closed)
 
-    def merge(self, other: "Grid", multi_index: MultiIndexSet) -> "Grid":
-        """Merge two instances of Grid with a new multi-index set.
+    # --- Special methods: Copies
+    # copying
+    def __copy__(self):
+        """Creates a shallow copy of the instance.
 
-        Parameters
-        ----------
-        other : Grid
-            Another instance of `Grid` to merge with the current instance.
-        multi_index : MultiIndexSet
-            The multi-index set of the merged instance.
+        This function is called when using the top-level function ``copy()``
+        on an instance of this class.
 
         Returns
         -------
         Grid
-            The merged instance with the given multi-index set.
-
-        Raises
-        ------
-        ValueError
-            If the generating functions of the instances are incompatible
-            with each other (if both are specified) or if the generating points
-            are incompatible with each other (if an instance is missing
-            a generating function).
-        """
-        if _have_gen_functions(self, other):
-            # Check if the Grid instances have compatible generating functions
-            if _have_compatible_gen_functions(self, other):
-                # The functions are compatible
-                gen_fun = self.generating_function
-                return self.__class__.from_function(multi_index, gen_fun)
-            else:
-                raise ValueError(
-                    "The Grid instance has an incompatible generating function"
-                    " with the other instance"
-                )
-
-        # Check if the Grid instances have compatible generating points
-        if _have_compatible_gen_points(self, other):
-            # Get the largest generating points from the two
-            gen_points = _get_larger_gen_points(self, other)
-            return self.__class__.from_points(multi_index, gen_points)
-
-        # Points are inconsistent
-        raise ValueError(
-            "The Grid instance has incompatible generating points "
-            "with the other instance"
-        )
-
-    # --- Special methods: Copies
-    # copying
-    def __copy__(self):
-        """Creates of a shallow copy.
-
-        This function is called, if one uses the top-level function ``copy()`` on an instance of this class.
-
-        :return: The copy of the current instance.
-        :rtype: Grid
+            A shallow copy of the current instance.
 
         See Also
         --------
         copy.copy
-            copy operator form the python standard library.
+            Copy operator from the Python standard library.
         """
         return self.__class__(
             self._multi_index,
             generating_function=self._generating_function,
             generating_points=self._generating_points,
+            domain=self._domain,
         )
 
     def __deepcopy__(self, mem):
         """Create of a deepcopy.
 
-        This function is called, if one uses the top-level function
+        This function is called if one uses the top-level function
         ``deepcopy()`` on an instance of this class.
 
         Returns
         -------
         Grid
             A deepcopy of the current instance where the underlying
-            multi-index set and the generating points are deepcopied.
+            multi-index set, the domain, and the generating points
+            are deepcopied.
 
         See Also
         --------
         copy.deepcopy
             copy function from the Python standard library.
         """
-        # Create a new instance with deep-copied multi-index set
-        multi_index = deepcopy(self._multi_index)
-        new_self = self._new_instance(multi_index)
+        # Create a new instance with a deep-copied multi-index set and domain
+        multi_index = deepcopy(self._multi_index, mem)
+        domain = deepcopy(self._domain, mem)
 
-        return new_self
+        return self._new_instance(multi_index, domain)
 
     # --- Dunder method: Callable instance
     def __call__(self, fun: Callable, *args, **kwargs) -> np.ndarray:
-        """Evaluate the given function on the unisolvent nodes of the grid.
+        """Evaluate a function on the unisolvent nodes in the given domain.
+
+        The function is evaluated at the unisolvent nodes transformed from
+        the canonical domain :math:`[-1, 1]^m` to the user-defined domain.
+        This allows users to define functions in their natural coordinate
+        system without manually handling domain transformations.
 
         Parameters
         ----------
         fun : Callable
-            The given function to evaluate. The function must accept as its
-            first argument a two-dimensional array and return as its output
-            an array of the same length as the input array.
+            The function to evaluate. Must accept as its first argument a
+            two-dimensional array of shape ``(N, m)`` and return an array of
+            length ``N``, where ``N`` is the number of unisolvent nodes
+            and ``m`` is the spatial dimension.
         *args
-            Additional positional arguments passed to the given function.
+            Additional positional arguments passed to the function.
         **kwargs
-            Additional keyword arguments passed to the given function.
+            Additional keyword arguments passed to the function.
 
         Returns
         -------
         :class:`numpy:numpy.ndarray`
-            The values of the given function evaluated on the unisolvent nodes
-            (i.e., the coefficients of the polynomial in the Lagrange basis).
+            The function values evaluated at the unisolvent nodes in the
+            user domain. These values correspond to the coefficients of
+            the polynomial in the Lagrange basis.
+
+        Notes
+        -----
+        - The unisolvent nodes are automatically transformed from
+          :math:`[-1, 1]^m` to the given domain before evaluation.
+        - If the domain is normalized (:math:`[-1, 1]^m`),
+          there no transformation takes place.
         """
         # No need for type checking the argument; rely on Python to raise any
         # exceptions when a problematic 'fun' is called on the nodes.
-        return fun(self.unisolvent_nodes, *args, **kwargs)
+        if self.domain.is_normalized:
+            xx = self.unisolvent_nodes
+        else:
+            xx = self.domain.map_from_normalized(self.unisolvent_nodes)
+        return fun(xx, *args, **kwargs)
 
     # --- Dunder methods: Rich comparison
     def __eq__(self, other: "Grid") -> bool:
@@ -739,7 +871,8 @@ class Grid:
 
         - both the underlying multi-index sets are equal, and
         - both the generating points are equal, and
-        - both the generating functions are equal.
+        - both the generating functions are equal, and
+        - both the underlying domains are equal.
 
         Parameters
         ----------
@@ -764,6 +897,10 @@ class Grid:
         if self.generating_function != other.generating_function:
             return False
 
+        # Domain equality
+        if self.domain != other.domain:
+            return False
+
         # Generating points equality
         if not np.array_equal(self.generating_points, other.generating_points):
             return False
@@ -776,44 +913,111 @@ class Grid:
 
     # --- Dunder methods: Arithmetics
     def __mul__(self, other: "Grid") -> "Grid":
-        """Multiply two instances of `Grid` via the ``*`` operator.
+        """Multiply two instances of Grid via the ``*`` operator.
+
+        Multiplying two instances of Grid creates a product grid with
+        a multi-index set that is the product of the underlying sets
+        of the two operands, and a domain that is the union of the two
+        underlying domains.
 
         Parameters
         ----------
-        other : `Grid`
-            The second operand of the grid multiplication.
+        other : Grid
+            The second Grid operand for multiplication.
 
         Returns
         -------
-        `Grid`
-            The product of two grids; the underlying multi-index set is
-            the product of the multi-index sets of the operands.
+        Grid
+            The product grid with:
+
+            - Product of the two multi-index sets
+            - Union of the two domains
+            - Compatible generating function or points
+
+        Notes
+        -----
+        - This operation provides the infrastructure for polynomial
+          multiplication: if polynomial ``p1`` is defined on ``grid1``
+          and ``p2`` on ``grid2``, then their product ``(p1 * p2)``
+          is naturally defined on ``(grid1 * grid2)``.
         """
         # Multiply the underlying multi-index sets
         mi_product = self.multi_index * other.multi_index
+        domain_union = self.domain | other.domain
 
-        return self.merge(other, mi_product)
+        #return self.merge(other, mi_product)
+        return self._combine_with(other, mi_product, domain_union)
 
     def __or__(self, other: "Grid") -> "Grid":
-        """Combine two instances of `Grid` via the ``|`` operator.
+        """Combine two instances of Grid via the ``|`` operator.
+
+        Combining two instances of Grid creates a union grid with a multi-index
+        set that is the union of the underlying sets of the two operands,
+        and a domain that is the union of the two underlying domains.
 
         Parameters
         ----------
-        other : `Grid`
-            The second operand of the grid union.
+        other : Grid
+            The second Grid operand for union.
 
         Returns
         -------
-        `Grid`
-            The union of two grids; the underlying multi-index set is
-            the union of the multi-index sets of the operands.
+        Grid
+            The union grid with:
+
+            - Union of the two multi-index sets
+            - Union of the two domains
+            - Compatible generating function or points
+
+        Notes
+        -----
+        - This operation provides the infrastructure for polynomial addition:
+          if polynomial ``p1`` is defined on ``grid1`` and ``p2`` on ``grid2``,
+          then their sum ``(p1 + p2)`` is naturally defined
+          on ``(grid1 | grid2)``.
         """
         # Add (union) the underlying multi-index sets
         mi_union = self.multi_index | other.multi_index
+        domain_union = self.domain | other.domain
 
-        return self.merge(other, mi_union)
+        return self._combine_with(other, mi_union, domain_union)
 
     # --- Private internal methods: not to be called directly from outside
+    def _combine_with(
+        self,
+        other: "Grid",
+        multi_index: MultiIndexSet,
+        domain: Domain,
+    ) -> "Grid":
+        """Combine two compatible grids with specified multi-index and domain.
+
+        This is a low-level helper used by grid operations, e.g., ``__mul__``,
+        ``__or__``. The multi-index set and domain are already computed by the
+        caller; this method picks the compatible generating data and constructs
+        a new instance of Grid.
+
+        Parameters
+        ----------
+        other : Grid
+            The other grid to combine with
+        multi_index : MultiIndexSet
+            The multi-index for the result
+        domain : Domain
+            The domain for the result
+
+        Returns
+        -------
+        Grid
+            New grid constructed with the given multi-index and domain
+        """
+        # Get the generating data
+        gen_fun, gen_points  = self._pick_generating_data(other)
+
+        if gen_fun is None:
+            return Grid.from_points(multi_index, gen_points, domain)
+
+        return Grid.from_function(multi_index, gen_fun, domain)
+
     def _create_generating_points(self) -> np.ndarray:
         """Construct generating points from the generating function.
 
@@ -833,6 +1037,94 @@ class Grid:
         generating_function = self._generating_function
 
         return generating_function(poly_degree, spatial_dimension)
+
+    def _expand_to_grid(self, target: "Grid") -> "Grid":
+        """Expand the dimension of the Grid to match that of a target Grid.
+
+        This method expands the dimension of the current Grid instance to
+        match the spatial dimension of the target Grid. Both the underlying
+        multi-index set and domain are expanded, and the grids must have
+        compatible generating functions or points.
+
+        Parameters
+        ----------
+        target : Grid
+            The target Grid whose dimension to match. Must have compatible
+            generating functions or points with the current Grid instance.
+
+        Returns
+        -------
+        Grid
+            A new instance of Grid with:
+
+            - Dimension matching the target Grid
+            - Expanded multi-index set
+            - Expanded domain
+            - Compatible generating function or points for both grids
+        """
+        # Expand the domain
+        domain_expanded = self.domain.expand_dim(target.domain)
+
+        # Expand the multi-index set
+        target_dimension = target.spatial_dimension
+        mi_expanded = self.multi_index.expand_dim(target_dimension)
+
+        # Combine with the target Grid and validates compatibility
+        return self._combine_with(target, mi_expanded, domain_expanded)
+
+    def _expand_to_dimension(self, target: int) -> "Grid":
+        """Expand the dimension of the Grid to a target dimension.
+
+        This method expands the dimension of the current Grid instance to
+        the specified dimension (given as integer).
+        The domain must be normalized to allow expansion, as the new dimension
+        is inferred to have the same normalized bounds.
+
+        Parameters
+        ----------
+        target : int
+            The target dimension to expand the Grid to. Must be greater than
+            or equal to the current dimension.
+
+        Returns
+        -------
+        Grid
+            A new instance of Grid with:
+
+            - Dimension equal to the target dimension
+            - Expanded multi-index set
+            - Expanded domain
+            - Same generating function or points as the current instance
+        """
+        # Expand the domain
+        domain_expanded = self.domain.expand_dim(target)
+
+        # Expand the multi-index set
+        mi_expanded = self.multi_index.expand_dim(target)
+
+        # Construct a new instance with the expanded components
+        if self._has_generating_function:
+            return self.__class__.from_function(
+                mi_expanded, self.generating_function, domain_expanded,
+            )
+
+        return self.__class__.from_points(
+            mi_expanded,
+            self.generating_points,
+            domain_expanded,
+        )
+
+    @property
+    def _has_generating_function(self) -> bool:
+        """Return ``True`` if the instance has a generating function.
+
+        Returns
+        -------
+        bool
+            ``True`` if the instance has a generating function assigned to it,
+            and ``False`` otherwise.
+        """
+        return self.generating_function is not None
 
     def _verify_generating_points(self):
         """Verify if the generating points are valid.
@@ -920,18 +1212,25 @@ class Grid:
                 f"of {max_exponent_multi_index}"
             )
 
-    def _new_instance(self, multi_index: MultiIndexSet) -> "Grid":
-        """Construct new grid instance with a new multi-index set.
+    def _new_instance(
+        self,
+        multi_index: MultiIndexSet,
+        domain: Optional[Domain] = None,
+    ) -> "Grid":
+        """Construct a new grid instance with a new multi-index set and domain.
 
         Parameters
         ----------
         multi_index : MultiIndexSet
             The multi-index set of the new instance.
+        domain : Domain, optional
+            The domain of the new instance. If not specified, the domain of
+            the current grid will be used.
 
         Returns
         -------
         Grid
-            The new instance of `Grid` with the given multi-index set.
+            A new instance of `Grid` with the given multi-index set.
 
         Notes
         -----
@@ -941,19 +1240,83 @@ class Grid:
           the generating function or the generating points, an exception
           will be raised.
         """
-        if self.has_generating_function:
+        if domain is None:
+            domain = self.domain
+
+        if self._has_generating_function:
             return self.__class__.from_function(
                 multi_index,
-                self.generating_function,
+                self._generating_function,
+                domain=domain,
             )
 
         return self.__class__.from_points(
             multi_index,
-            self.generating_points,
+            self._generating_points,
+            domain=domain,
         )
+
+    def _pick_generating_data(
+        self,
+        other: "Grid",
+    ) -> Tuple[Optional[GEN_FUNCTION], Optional[np.ndarray]]:
+        """Pick generating data from two compatible grids.
+
+        This private method validates that the two grids have compatible
+        generating functions or generating points, then selects the appropriate
+        generating data to use for constructing a combined grid.
+        If both grids have compatible generating functions,
+        the generating function; otherwise, the larger set of generating points
+        is used.
+
+        Parameters
+        ----------
+        other : Grid
+            Another instance of Grid to pick compatible generating data from.
+
+        Returns
+        -------
+        Tuple[Optional[GEN_FUNCTION], Optional[np.ndarray]]
+            A tuple containing either (Only one element of the tuple will be
+            non-None):
+
+            - (generating_function, None) if both grids have compatible
+              functions
+            - (None, generating_points) if grids have compatible points.
+
+        Raises
+        ------
+        ValueError
+            If the grids are not compatible.
+
+        Notes
+        -----
+        - This is a low-level helper method used internally by grid combination
+          operations (__mul__, __or__, expand_dim). Compatibility is determined
+          by the is_compatible() method.
+        """
+        if self.has_compatible_gen_function(other):
+            return self.generating_function, None
+
+        if self.has_compatible_gen_points(other):
+            gen_points = _get_larger_gen_points(self, other)
+            return None, gen_points
+
+        raise ValueError(
+                "Cannot pick generating data from incompatible grids. "
+                "Grids must have matching generating functions or compatible "
+                "generating points."
+            )
 
 
 # --- Internal helper functions
+def _gen_unisolvent_nodes(multi_index, generating_points):
+    """
+    .. todo::
+        - document this function but ship it to utils first.
+    """
+    return np.take_along_axis(generating_points, multi_index.exponents, axis=0)
+
 def _process_multi_index(multi_index: MultiIndexSet) -> MultiIndexSet:
     """Process the MultiIndexSet given as an argument to Grid constructor.
 
@@ -983,6 +1346,45 @@ def _process_multi_index(multi_index: MultiIndexSet) -> MultiIndexSet:
         raise ValueError("MultiIndexSet must not be empty!")
 
     return multi_index
+
+
+def _process_domain(domain: Domain, multi_index: MultiIndexSet) -> Domain:
+    """Process the Domain given as an argument to Grid constructor.
+
+    Parameters
+    ----------
+    domain : Domain
+        The domain as input argument to the Grid constructor to be
+        processed.
+    multi_index : MultiIndexSet
+        The multi-index set as input argument to the Grid constructor to be
+        processed.
+
+    Returns
+    -------
+    Domain
+        The same instance of :class:`Domain` if processing does not
+        raise any exceptions.
+
+    Raises
+    ------
+    TypeError
+        If the domain argument is not an instance of :class:`Domain`.
+    ValueError
+        If the domain argument does not have the same spatial dimension as
+        the multi-index set.
+    """
+    check_type(domain, Domain)
+
+    # Spatial dimensions must be consistent
+    if domain.spatial_dimension != multi_index.spatial_dimension:
+        raise ValueError(
+            f"Spatial dimension of the domain ({domain.spatial_dimension}) is "
+            "inconsistent with that of the multi-index set "
+            f"({multi_index.spatial_dimension})"
+        )
+
+    return domain
 
 
 def _process_generating_function(
@@ -1016,139 +1418,6 @@ def _process_generating_function(
     raise TypeError(
         f"The generating function {generating_function} is not callable"
     )
-
-
-def _expand_dim_to_target_dim(
-    origin_grid: "Grid",
-    target_dimension: int,
-) -> "Grid":
-    """Expand the dimension of a given Grid to a target dimension.
-
-    Parameters
-    ----------
-    origin_grid : Grid
-        The `Grid` instance whose dimension is to be expanded.
-    target_dimension : Grid
-        The target dimension; must be equal to or larger than the current
-        dimension of the `Grid` instance.
-
-    Returns
-    -------
-    Grid
-        The grid with an expanded dimension.
-
-    Raises
-    ------
-    ValueError
-        If the target dimension cannot be accommodated by the available
-        generating points.
-    """
-    # Expand the dimension of the multi-index set
-    mi_expanded = origin_grid.multi_index.expand_dim(target_dimension)
-
-    # Check if a generating function is available
-    if origin_grid.has_generating_function:
-        return origin_grid.__class__.from_function(
-            mi_expanded,
-            origin_grid.generating_function,
-        )
-
-    # Check if the available generating points can accommodate higher dimension
-    gen_points_dim = origin_grid.generating_points.shape[1]
-    if gen_points_dim >= target_dimension:
-        return origin_grid.__class__.from_points(
-            mi_expanded,
-            origin_grid.generating_points,
-        )
-
-    raise ValueError(
-        f"The available dimension of the generating points ({gen_points_dim} "
-        f"can't accommodate target dimension ({target_dimension})"
-    )
-
-
-def _expand_dim_to_target_grid(
-    origin_grid: "Grid",
-    target_grid: "Grid",
-) -> "Grid":
-    """Expand the dimension of a given Grid to the dimension of another.
-
-    Parameters
-    ----------
-    origin_grid : Grid
-        The grid whose dimension is to be expanded.
-    target_grid : Grid
-        The grid whose dimension is the base for expansion.
-
-    Returns
-    -------
-    Grid
-        The grid with an expanded dimension.
-
-    Raises
-    ------
-    ValueError
-        If the generating functions are not compatible (when available) or
-        if the generating points are not compatible.
-    """
-    # Create expanded multi-index set
-    target_dim = target_grid.spatial_dimension
-    mi_expanded = origin_grid.multi_index.expand_dim(target_dim)
-
-    return origin_grid.merge(target_grid, mi_expanded)
-
-
-def _have_gen_functions(*grids) -> bool:
-    """Check if a sequence of Grid instances all have generating function."""
-    return all(grd.has_generating_function for grd in grids)
-
-
-def _have_compatible_gen_functions(grid_1: "Grid", grid_2: "Grid") -> bool:
-    """Check if two grids have compatible generating functions.
-
-    Parameters
-    ----------
-    grid_1 : Grid
-        First instance of `Grid` to compare.
-    grid_2 : Grid
-        Second instance of `Grid` to compare.
-    """
-    # There is no way in Python to check for equality to what functions do
-    return (
-        grid_1.has_generating_function
-        and grid_2.has_generating_function
-        and grid_1.generating_function == grid_2.generating_function
-    )
-
-
-def _have_compatible_gen_points(grid_1: "Grid", grid_2: "Grid") -> bool:
-    """Check if two grids have compatible generating points.
-
-    Parameters
-    ----------
-    grid_1 : Grid
-        First `Grid` instance to compare.
-    grid_2 : Grid
-        Second `Grid` instance to compare.
-
-    Returns
-    -------
-    bool
-        ``True`` if all generating points in the common spatial dimension
-        of the two `Grid` instances are equal; ``False`` otherwise.
-    """
-    dim_1 = grid_1.spatial_dimension
-    dim_2 = grid_2.spatial_dimension
-    dim = np.min([dim_1, dim_2])
-
-    row_1 = grid_1.generating_points.shape[0]
-    row_2 = grid_2.generating_points.shape[0]
-    row = np.min([row_1, row_2])
-
-    gen_points_1 = grid_1.generating_points[:row, :dim]
-    gen_points_2 = grid_2.generating_points[:row, :dim]
-
-    return np.array_equal(gen_points_1, gen_points_2)
 
 
 def _get_larger_gen_points(grid_1: "Grid", grid_2: "Grid") -> np.ndarray:

--- a/src/minterpy/polynomials/newton_polynomial.py
+++ b/src/minterpy/polynomials/newton_polynomial.py
@@ -557,8 +557,8 @@ def _is_compute_coeffs_poly_sum_via_monomials(
     # If one of the operands is a scalar polynomial
     is_scalar_poly = is_scalar(poly_1) or is_scalar(poly_2)
     # ...or if the grids are compatible
-    is_compatible_grid_1 = poly_1.grid.is_compatible(grid_sum)
-    is_compatible_grid_2 = poly_2.grid.is_compatible(grid_sum)
+    is_compatible_grid_1 = poly_1.grid.has_compatible_gen_points(grid_sum)
+    is_compatible_grid_2 = poly_2.grid.has_compatible_gen_points(grid_sum)
     is_compatible_grids = is_compatible_grid_1 and is_compatible_grid_2
 
     return is_scalar_poly or is_compatible_grids

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,3 +1,4 @@
+import copy
 import numpy as np
 import pytest
 
@@ -7,6 +8,7 @@ from minterpy.gen_points import (
     gen_chebychev_2nd_order_leja_ordered,
     gen_points_from_values,
 )
+from minterpy.core.domain import Domain
 from minterpy.core.grid import DEFAULT_FUN
 from minterpy.utils.multi_index import get_exponent_matrix
 
@@ -24,6 +26,22 @@ def _fun_one_out(xx: np.ndarray, sum: bool = False):
 def _fun_multi_out(xx: np.ndarray):
     """Return the same output as input."""
     return xx  # xx is assumed to be multi-dimensional
+
+
+@pytest.fixture
+def normalized_domain(SpatialDimension) -> Domain:
+    """Normalized domain for testing."""
+    return Domain.normalized(SpatialDimension)
+
+@pytest.fixture
+def random_unif_domain(SpatialDimension) -> Domain:
+    """Create a random uniform domain for testing"""
+    # Create a custom domain
+    lb = np.random.randint(0, 10)
+    ub = lb + np.random.randint(1, 10)
+    domain = Domain.uniform(SpatialDimension, lb, ub)
+
+    return domain
 
 
 class TestInit:
@@ -103,6 +121,35 @@ class TestInit:
                 generating_function=_gen_fun,
                 generating_points=gen_points,
             )
+
+    def test_with_default_domain(self, multi_index_mnp, normalized_domain):
+        """Constructing a Grid with a default domain."""
+        # Get the complete multi-index set
+        mi = multi_index_mnp
+
+        # Construct a grid with defaults
+        grd = Grid(mi)
+
+        # Assertions
+        assert grd.domain == normalized_domain
+        assert grd.domain.spatial_dimension == grd.spatial_dimension
+
+    def test_with_custom_domain(self, multi_index_mnp, random_unif_domain):
+        """Test constructing a Grid with a custom domain."""
+
+        # Create a Grid instance with the custom domain
+        grd = Grid(multi_index_mnp, domain=random_unif_domain)
+
+        # Assertions
+        assert grd.domain == random_unif_domain
+        assert grd.domain.spatial_dimension == grd.spatial_dimension
+
+    def test_with_invalid_domain(self, multi_index_mnp):
+        """Test constructing a Grid with an invalid domain."""
+
+        dim = multi_index_mnp.spatial_dimension + 1
+        with pytest.raises(ValueError):
+            _ = Grid(multi_index_mnp, domain=Domain.normalized(dim))
 
 
 class TestInitGenPoints:
@@ -291,6 +338,31 @@ class TestInitFrom:
         assert grd_1 == grd_2
         assert grd_2 == grd_1
 
+    def test_from_degree_with_domain(
+        self,
+        SpatialDimension,
+        PolyDegree,
+        LpDegree,
+    ):
+        """Test the `from_degree()` method with domain."""
+        # Create a complete multi-index set
+        mi = MultiIndexSet.from_degree(SpatialDimension, PolyDegree, LpDegree)
+        # Create a normalized domain
+        domain = Domain.normalized(SpatialDimension)
+
+        # Create a grid
+        grd_1 = Grid(mi, domain=domain)
+        grd_2 = Grid.from_degree(
+            SpatialDimension,
+            PolyDegree,
+            LpDegree,
+            domain=domain,
+        )
+
+        # Assertions
+        assert grd_1 == grd_2
+        assert grd_2 == grd_1
+
     def test_from_gen_function(self, multi_index_mnp):
         """Test the `from_function()` method."""
         # Get the complete multi-index set
@@ -315,6 +387,22 @@ class TestInitFrom:
         # Create instances of Grid
         grd_1 = Grid(mi, generating_function=DEFAULT_FUN)
         grd_2 = Grid.from_function(mi, DEFAULT_FUN)
+
+        # Assertion
+        assert grd_1 == grd_2
+        assert grd_2 == grd_1
+
+    def test_from_gen_function_with_domain(self, multi_index_mnp):
+        """Test the `from_function()` method with domain."""
+        # Get the complete multi-index set
+        mi = multi_index_mnp
+
+        # Create a uniform domain
+        domain = Domain.uniform(mi.spatial_dimension, 0, 1)
+
+        # Create instances of Grid
+        grd_1 = Grid(mi, generating_function=DEFAULT_FUN, domain=domain)
+        grd_2 = Grid.from_function(mi, DEFAULT_FUN, domain=domain)
 
         # Assertion
         assert grd_1 == grd_2
@@ -347,6 +435,26 @@ class TestInitFrom:
         # Create instances of Grid
         grd_1 = Grid(mi, generating_points=gen_points)
         grd_2 = Grid.from_points(mi, gen_points)
+
+        # Assertions
+        assert grd_1 == grd_2
+        assert grd_2 == grd_1
+
+    def test_from_gen_points_with_domain(self, multi_index_mnp):
+        """Test the `from_points()` method with domain."""
+        # Get the complete multi-index set
+        mi = multi_index_mnp
+
+        # Create an array of generating points
+        gen_function = GENERATING_FUNCTIONS[DEFAULT_FUN]
+        gen_points = gen_function(mi.max_exponent, mi.spatial_dimension)
+
+        # Create a uniform domain
+        domain = Domain.uniform(mi.spatial_dimension, 0, 1)
+
+        # Create instances of Grid
+        grd_1 = Grid(mi, generating_points=gen_points, domain=domain)
+        grd_2 = Grid.from_points(mi, gen_points, domain=domain)
 
         # Assertions
         assert grd_1 == grd_2
@@ -403,6 +511,27 @@ class TestInitFrom:
         assert grd_1 == grd_2
         assert grd_2 == grd_1
 
+    def test_from_value_set_with_domain(self, multi_index_mnp):
+        """Test the `from_value_set()` method with domain."""
+        # Get the complete multi-index set
+        mi = multi_index_mnp
+
+        # Create an array of generating values (the default 1d generating
+        # function) and the corresponding generating points
+        gen_values = gen_chebychev_2nd_order_leja_ordered(mi.max_exponent)
+        gen_points = gen_points_from_values(gen_values, mi.spatial_dimension)
+
+        # Create a uniform domain
+        domain = Domain.uniform(mi.spatial_dimension, 0, 1)
+
+        # Create instances of Grid
+        grd_1 = Grid(mi, generating_points=gen_points, domain=domain)
+        grd_2 = Grid.from_value_set(mi, gen_values, domain=domain)
+
+        # Assertions
+        assert grd_1 == grd_2
+        assert grd_2 == grd_1
+
     def test_from_value_set_invalid_wrong_shape(self, multi_index_mnp):
         """Test invalid call to `from_value_set()` due to wrong shape."""
         # Get the complete multi-index set
@@ -432,6 +561,26 @@ class TestInitFrom:
         with pytest.raises(ValueError):
             Grid.from_value_set(mi, gen_values)
 
+
+class TestDomainProperty:
+    """All tests related to the domain property of the Grid instance."""
+
+    def test_read_only(self, multi_index_mnp):
+        """Test the property is read-only."""
+        # Create a Grid instance
+        grd = Grid(multi_index_mnp)
+
+        # Assertion
+        with pytest.raises(AttributeError):
+            grd.domain = np.arange(10)
+
+    def test_always_exist(self, multi_index_mnp):
+        """Test the property is read-only."""
+        # Create a Grid instance
+        grd = Grid(multi_index_mnp)
+
+        # Assertion
+        assert grd.domain is not None
 
 class TestUnisolventNodes:
     """All tests related to the unisolvent nodes property."""
@@ -491,6 +640,21 @@ class TestCall:
         assert len(lag_coeffs_2) == len(mi)
         assert np.array_equal(lag_coeffs_1, lag_coeffs_2)
 
+    def test_call_custom_domain(self, multi_index_mnp, random_unif_domain):
+        """Test calling on a valid callable with custom domain."""
+        # Create a Grid
+        grd = Grid(multi_index_mnp, domain=random_unif_domain)
+
+        # Call the Grid instance
+        yy_1 = grd(_fun_one_out, sum=True)
+        yy_2 = _fun_one_out(
+            random_unif_domain.map_from_normalized(grd.unisolvent_nodes),
+            sum=True,
+        )
+
+        # Assertions
+        assert np.array_equal(yy_1, yy_2)
+
     @pytest.mark.parametrize("invalid_function", [1, 2.0, "3.5"])
     def test_call_invalid_function(self, multi_index_mnp, invalid_function):
         """Test calling on an invalid function."""
@@ -538,6 +702,7 @@ class TestExpandDim:
         assert grd_expanded != grd
         assert grd_expanded.spatial_dimension == new_dim
         assert grd_expanded.multi_index == mi.expand_dim(new_dim)
+        assert grd_expanded.domain == grd.domain.expand_dim(new_dim)
 
     def test_target_dim_same_dim_with_gen_points(self, multi_index_mnp):
         """Test expanding to the same dimension with generating points."""
@@ -574,6 +739,7 @@ class TestExpandDim:
 
         # Assertion
         assert grd_expanded.spatial_dimension == target_dim
+        assert grd_expanded.domain == grd.domain.expand_dim(target_dim)
 
     def test_target_dim_with_gen_points_invalid(self, multi_index_mnp):
         """Test expanding the dimension with invalid generating points."""
@@ -634,6 +800,7 @@ class TestExpandDim:
         expanded_dim = expanded_grid.spatial_dimension
         target_dim = target_grid.spatial_dimension
         assert expanded_dim == target_dim
+        assert expanded_grid.domain == target_grid.domain
 
     def test_target_grid_with_larger_origin_gen_points(self, multi_index_mnp):
         """Test expanding the dimension to the dimension of a target grid
@@ -668,6 +835,7 @@ class TestExpandDim:
         assert np.all(
             expanded_grid.generating_points == origin_grid.generating_points
         )
+        assert expanded_grid.domain == target_grid.domain
 
     def test_target_grid_with_gen_points_invalid(self, multi_index_mnp):
         """Test expanding the dimension to the dimension of a target grid
@@ -717,6 +885,7 @@ class TestExpandDim:
         assert np.all(
             expanded_grid.generating_points == target_grid.generating_points
         )
+        assert expanded_grid.domain == target_grid.domain
 
     def test_target_grid_with_gen_fun_invalid(self, multi_index_mnp):
         """Test expanding the dimension to the dimension of a target grid
@@ -729,7 +898,7 @@ class TestExpandDim:
 
         # Get the ingredients for a Grid
         origin_gen_fun = GENERATING_FUNCTIONS[DEFAULT_FUN]
-        target_gen_fun = lambda x, y: origin_gen_fun(x, y)
+        target_gen_fun = lambda x, y: 0.99 * origin_gen_fun(x, y)
 
         # Create instances of Grid
         origin_grid = Grid.from_function(origin_mi, origin_gen_fun)
@@ -743,14 +912,23 @@ class TestExpandDim:
 class TestEquality:
     """All tests related to equality check of Grid instances."""
 
-    def test_equal(self, SpatialDimension, PolyDegree, LpDegree):
+    def test_equal_multi_index(self, multi_index_mnp):
         """Test equality of two Grid instances."""
-        # Create a common multi-index set
-        mi = MultiIndexSet.from_degree(SpatialDimension, PolyDegree, LpDegree)
+        # Create two Grid instances equal in value
+        grd_1 = Grid(multi_index_mnp)
+        grd_2 = Grid(multi_index_mnp)
+
+        # Assertions
+        assert grd_1 is not grd_2  # Not identical instances
+        assert grd_1 == grd_2  # but equal in value
+        assert grd_2 == grd_1  # symmetric property
+
+    def test_equal_domain(self, multi_index_mnp, random_unif_domain):
+        """Test equality of two Grid instances with custom but equal domain."""
 
         # Create two Grid instances equal in value
-        grd_1 = Grid(mi)
-        grd_2 = Grid(mi)
+        grd_1 = Grid(multi_index_mnp, domain=random_unif_domain)
+        grd_2 = Grid(multi_index_mnp, domain=random_unif_domain)
 
         # Assertions
         assert grd_1 is not grd_2  # Not identical instances
@@ -779,13 +957,31 @@ class TestEquality:
         mi = MultiIndexSet.from_degree(SpatialDimension, PolyDegree, LpDegree)
 
         # Create two Grid instances with different generating points
-        # Chebyshev points
-        grd_1 = Grid(mi)
+        # Chebyshev points (the default)
+        grd_ = Grid(mi)
+        grd_1 = Grid.from_points(mi, grd_.generating_points)
         # Equidistant points
         grd_2 = Grid.from_value_set(
             mi,
             np.linspace(-0.99, 0.99, PolyDegree+1)[:, np.newaxis],
         )
+
+        # Assertions
+        assert grd_1 is not grd_2  # Not identical instances
+        assert grd_1 != grd_2  # Not equal in values
+        assert grd_2 != grd_1  # symmetric property
+
+    def test_unequal_domain(self, multi_index_mnp):
+        """Test inequality of two Grid instances due to different domains.
+        """
+        # Create two different domains
+        dim = multi_index_mnp.spatial_dimension
+        domain_1 = Domain.uniform(dim, 0, 1)
+        domain_2 = Domain.normalized(dim)
+
+        # Create two Grid instances
+        grd_1 = Grid(multi_index_mnp, domain=domain_1)
+        grd_2 = Grid(multi_index_mnp, domain=domain_2)
 
         # Assertions
         assert grd_1 is not grd_2  # Not identical instances
@@ -824,6 +1020,7 @@ class TestMultiplication:
         # Assertions
         assert grd_prod.multi_index == mi * mi
         assert len(grd_prod.unisolvent_nodes) == len(mi * mi)
+        assert grd_prod.domain == grd.domain | grd.domain
 
     def test_with_gen_points(self):
         """Test the multiplication of instances having only gen. points."""
@@ -848,6 +1045,7 @@ class TestMultiplication:
         assert grd_prod.multi_index == mi_1 * mi_2
         assert len(grd_prod.unisolvent_nodes) == len(mi_1 * mi_2)
         assert np.all(grd_prod.generating_points == gen_points_2)
+        assert grd_prod.domain == grd_1.domain | grd_2.domain
 
     @pytest.mark.parametrize("invalid_value", [1.0, 2, "123", np.array([1])])
     def test_invalid(self, multi_index_mnp, invalid_value):
@@ -903,6 +1101,7 @@ class TestUnion:
         assert grd_prod.multi_index == mi_1 | mi_2
         assert len(grd_prod.unisolvent_nodes) == len(mi_1 | mi_2)
         assert np.all(grd_prod.generating_points == gen_points_2)
+        assert grd_prod.domain == grd_1.domain | grd_2.domain
 
     @pytest.mark.parametrize("invalid_value", [1.0, 2, "123", np.array([1])])
     def test_invalid(self, multi_index_mnp, invalid_value):
@@ -934,6 +1133,7 @@ class TestAddExponents:
         # Assertion
         assert grd == grd_added
         assert grd_added == grd
+        assert grd.domain == grd_added.domain  # Domain is preserved
 
     def test_too_large_exponent(self, multi_index_mnp):
         """Test adding an exponent that cannot be supported by the grid."""
@@ -983,6 +1183,7 @@ class TestAddExponents:
         # Assertion
         assert grd_1_added == grd_2
         assert grd_2 == grd_1_added
+        assert grd_2.domain == grd_1_added.domain  # Domain is preserved
 
 
 class TestMakeComplete:
@@ -1003,6 +1204,7 @@ class TestMakeComplete:
         assert grd_complete == grd
         assert grd == grd_complete
         assert grd is not grd_complete
+        assert grd.domain == grd_complete.domain  # Domain is preserved
 
     def test_incomplete(self, multi_index_incomplete):
         """Test making an incomplete grid complete."""
@@ -1018,6 +1220,7 @@ class TestMakeComplete:
         # Assertions
         assert not grd.is_complete
         assert grd_complete.is_complete
+        assert grd.domain == grd_complete.domain  # Domain is preserved
 
 
 class TestMakeDownwardClosed:
@@ -1038,6 +1241,7 @@ class TestMakeDownwardClosed:
         assert grd_downward_closed == grd
         assert grd == grd_downward_closed
         assert grd is not grd_downward_closed
+        assert grd.domain == grd_downward_closed.domain  # Domain is preserved
 
     def test_non_downward_closed(self, multi_index_non_downward_closed):
         """Test making a non-downward-closed grid downward-closed."""
@@ -1053,6 +1257,7 @@ class TestMakeDownwardClosed:
         # Assertions
         assert not grd.is_downward_closed
         assert grd_downward_closed.is_downward_closed
+        assert grd.domain == grd_downward_closed.domain  # Domain is preserved
 
 
 class TestIsCompatible:
@@ -1120,7 +1325,7 @@ class TestIsCompatible:
             if xx.ndim == 1:
                 xx = xx[:, np.newaxis]
             generating_points = np.tile(xx, (1, spatial_dimension))
-            generating_points[:, ::2] *= -1
+            generating_points[:, ::2] *= -0.9
 
             return generating_points
 
@@ -1131,3 +1336,33 @@ class TestIsCompatible:
         # Assertion
         assert not grd_1.is_compatible(grd_2)
         assert not grd_2.is_compatible(grd_1)  # Commutativity must hold
+
+
+class TestCopy:
+    """All tests related to copy behavior of Grid instances."""
+
+    def test_shallow(self, multi_index_mnp, random_unif_domain):
+        """Test the behavior of shallow copy."""
+        grd = Grid(multi_index_mnp, domain=random_unif_domain)
+
+        grd_copy = copy.copy(grd)
+
+        # Assertions
+        assert grd is not grd_copy
+        assert grd.multi_index is grd_copy.multi_index
+        assert grd.domain is grd_copy.domain
+        assert grd.generating_function is grd_copy.generating_function
+        assert grd.generating_points is not grd_copy.generating_points
+
+    def test_deep(self, multi_index_mnp, random_unif_domain):
+        """Test the behavior of deep copy."""
+        grd = Grid(multi_index_mnp, domain=random_unif_domain)
+
+        grd_copy = copy.deepcopy(grd)
+
+        # Assertions
+        assert grd is not grd_copy
+        assert grd.multi_index is not grd_copy.multi_index
+        assert grd.domain is not grd_copy.domain
+        assert grd.generating_function is grd_copy.generating_function
+        assert grd.generating_points is not grd_copy.generating_points


### PR DESCRIPTION
The Domain class has been integrated as a property of the Grid class for dealing with custom rectangular domains while maintaining backward compatibility with normalized [-1, 1]^m domain.

Several key changes:

- Add optional `domain` parameter to Grid constructor and all factory methods
- Domain defaults to normalized `Domain.normalized(m)` when not specified
- Add `domain` property
- Update `__call__` to transform unisolvent_nodes to user domain before evaluation
- Add domain equality check to `__eq__` taking into account the domain
- Update `__mul__` and `__or__` to combine domains via domain union (|)

The test suite has been updated accordingly.

This PR should resolve Issue #52.