### PR TITLE
Integrate Domain class and remove legacy domain properties

### DIFF
--- a/src/minterpy/core/ABC/multivariate_polynomial_abstract.py
+++ b/src/minterpy/core/ABC/multivariate_polynomial_abstract.py
@@ -23,12 +23,8 @@ from minterpy.core.domain import Domain
 from minterpy.core.grid import Grid
 from minterpy.core.multi_index import MultiIndexSet
 from minterpy.utils.verification import (
-    check_type,
-    check_values,
     is_real_scalar,
-    check_shape,
     shape_eval_output,
-    verify_domain,
     verify_poly_coeffs,
     verify_poly_power,
     verify_query_points,
@@ -212,7 +208,7 @@ class MultivariatePolynomialABC(abc.ABC):
 
 
 class MultivariatePolynomialSingleABC(MultivariatePolynomialABC):
-    """abstract base class for "single instance" multivariate polynomials
+    """Abstract base class for "single instance" multivariate polynomials
 
     Attributes
     ----------
@@ -220,20 +216,10 @@ class MultivariatePolynomialSingleABC(MultivariatePolynomialABC):
         The multi-index set of the multivariate polynomial.
     coeffs : np.ndarray, optional
         Coefficients of the polynomial. If ``None``, the polynomial is
-        uninitialized. Either one-dimensional array of length equal to
-        the number of monomials, or two-dimensional array of shape
+        uninitialized. Either a one-dimensional array of length equal to
+        the number of monomials or a two-dimensional array of shape
         ``(num_monomials, num_polynomials)`` for multiple polynomials
         sharing the same multi-index set.
-    internal_domain : array_like
-        **Deprecated**. The domain the polynomial is defined on
-        (basically the domain of the unisolvent nodes).
-        Either one-dimensional domain (min,max), a stack of domains for each
-        domain with shape (spatial_dimension,2).
-    user_domain : array_like
-        **Deprecated**. The domain where the polynomial can be evaluated.
-        This will be mapped onto the ``internal_domain``.
-        Either one-dimensional domain ``min,max)`` a stack of domains for each
-        domain with shape ``(spatial_dimension,2)``.
     grid : Grid, optional
         The underlying grid on which the (interpolating) polynomial is defined.
         If not given, the default Grid instance will be constructed.
@@ -243,27 +229,13 @@ class MultivariatePolynomialSingleABC(MultivariatePolynomialABC):
 
     Notes
     -----
-    - The multi-index set associated with ``grid`` may be different than
+    - The multi-index set associated with ``grid`` may be different from
       ``multi_index``. All indices from ``multi_index`` must be contained
       in ``grid.multi_index``.
     """
     # __doc__ += __doc_attrs__
 
     _coeffs: Optional[ARRAY] = None
-
-    @staticmethod
-    @abc.abstractmethod
-    def generate_internal_domain(
-        internal_domain, spatial_dimension
-    ):  # pragma: no cover
-        # no docstring here, since it is given in the concrete implementation
-        pass
-
-    @staticmethod
-    @abc.abstractmethod
-    def generate_user_domain(user_domain, spatial_dimension):  # pragma: no cover
-        # no docstring here, since it is given in the concrete implementation
-        pass
 
     # TODO static methods should not have a parameter "self"
     @staticmethod
@@ -301,20 +273,6 @@ class MultivariatePolynomialSingleABC(MultivariatePolynomialABC):
     def _scalar_add(poly, scalar):  # pragma: no cover
         # no docstring here, since it is given in the concrete implementation
         pass
-
-    # @staticmethod
-    # def _gen_grid_default(multi_index):
-    #     """Return the default :class:`Grid` for a given :class:`MultiIndexSet` instance.
-    #
-    #     For the default values of the Grid class, see :class:`minterpy.Grid`.
-    #
-    #
-    #     :param multi_index: An instance of :class:`MultiIndexSet` for which the default :class:`Grid` shall be build
-    #     :type multi_index: MultiIndexSet
-    #     :return: An instance of :class:`Grid` with the default optional parameters.
-    #     :rtype: Grid
-    #     """
-    #     return Grid(multi_index)
 
     @staticmethod
     @abc.abstractmethod
@@ -449,8 +407,6 @@ class MultivariatePolynomialSingleABC(MultivariatePolynomialABC):
         self,
         multi_index: Union[MultiIndexSet, ARRAY],
         coeffs: Optional[ARRAY] = None,
-        internal_domain: Optional[ARRAY] = None,
-        user_domain: Optional[ARRAY] = None,
         grid: Optional[Grid] = None,
         domain: Optional[Domain] = None,
     ):
@@ -463,24 +419,8 @@ class MultivariatePolynomialSingleABC(MultivariatePolynomialABC):
             # TODO should passing multi indices as ndarray be supported?
             self.multi_index = MultiIndexSet(multi_index)
 
-        nr_monomials, spatial_dimension = self.multi_index.exponents.shape
+        # Verify and assign grid (delegate to setter)
         self.coeffs = coeffs  # calls the setter method and checks the input shape
-
-        if internal_domain is not None:
-            check_type(internal_domain, np.ndarray)
-            check_values(internal_domain)
-            check_shape(internal_domain, shape=(2, spatial_dimension))
-        self.internal_domain = self.generate_internal_domain(
-            internal_domain, self.multi_index.spatial_dimension
-        )
-
-        if user_domain is not None:  # TODO not better "external domain"?!
-            check_type(user_domain, np.ndarray)
-            check_values(user_domain)
-            check_shape(user_domain, shape=(2, spatial_dimension))
-        self.user_domain = self.generate_user_domain(
-            user_domain, self.multi_index.spatial_dimension
-        )
 
         # Verify and assign grid
         self._grid: Grid = _verify_grid(self.multi_index, grid, domain)
@@ -504,8 +444,6 @@ class MultivariatePolynomialSingleABC(MultivariatePolynomialABC):
         poly_degree: int,
         lp_degree: float,
         coeffs: Optional[ARRAY] = None,
-        internal_domain: ARRAY = None,
-        user_domain: ARRAY = None,
         grid: Optional[Grid] = None,
         domain: Optional[Domain] = None,
     ):
@@ -534,10 +472,6 @@ class MultivariatePolynomialSingleABC(MultivariatePolynomialABC):
             the number of monomials, or two-dimensional array of shape
             ``(num_monomials, num_polynomials)`` for multiple polynomials
             sharing the same multi-index set.
-        internal_domain : np.ndarray, optional
-            **Deprecated**. Use ``domain`` parameter instead.
-        user_domain : np.ndarray, optional
-            **Deprecated**. Use ``domain`` parameter instead.
         grid : Grid, optional
             The underlying grid on which the polynomial is defined.
             If not given, a default Grid instance will be constructed.
@@ -557,7 +491,7 @@ class MultivariatePolynomialSingleABC(MultivariatePolynomialABC):
             lp_degree,
         )
 
-        return cls(mi, coeffs, internal_domain, user_domain, grid, domain)
+        return cls(mi, coeffs, grid, domain)
 
     @classmethod
     def from_poly(
@@ -606,8 +540,6 @@ class MultivariatePolynomialSingleABC(MultivariatePolynomialABC):
         return cls(
             copy(p.multi_index),
             new_coeffs,
-            p.internal_domain,
-            p.user_domain,
             copy(p.grid),
         )
 
@@ -616,8 +548,6 @@ class MultivariatePolynomialSingleABC(MultivariatePolynomialABC):
         cls,
         grid: Grid,
         coeffs: Optional[np.ndarray] = None,
-        internal_domain: Optional[np.ndarray] = None,
-        user_domain: Optional[np.ndarray] = None,
     ):
         """Create an instance of polynomial with a `Grid` instance.
 
@@ -632,10 +562,6 @@ class MultivariatePolynomialSingleABC(MultivariatePolynomialABC):
             coefficients of a single polynomial on the same grid.
             This parameter is optional, if not specified the polynomial
             is considered "uninitialized".
-        internal_domain  : :class:`numpy:numpy.ndarray`, optional
-            The internal domain of the polynomial(s).
-        user_domain : :class:`numpy:numpy.ndarray`, optional
-            The user domain of the polynomial(s).
 
         Returns
         -------
@@ -645,8 +571,6 @@ class MultivariatePolynomialSingleABC(MultivariatePolynomialABC):
         return cls(
             multi_index=grid.multi_index,
             coeffs=coeffs,
-            internal_domain=internal_domain,
-            user_domain=user_domain,
             grid=grid,
         )
 
@@ -1172,11 +1096,10 @@ class MultivariatePolynomialSingleABC(MultivariatePolynomialABC):
         copy.copy
             copy operator form the python standard library.
         """
+        # TODO: Use copy for each instance to propagate consistent behavior
         return self.__class__(
             self.multi_index,
             self._coeffs,
-            self.internal_domain,
-            self.user_domain,
             self.grid,
         )
 
@@ -1197,8 +1120,6 @@ class MultivariatePolynomialSingleABC(MultivariatePolynomialABC):
         return self.__class__(
             deepcopy(self.multi_index),
             deepcopy(self._coeffs),
-            deepcopy(self.internal_domain),
-            deepcopy(self.user_domain),
             deepcopy(self.grid),
         )
 

--- a/src/minterpy/core/domain.py
+++ b/src/minterpy/core/domain.py
@@ -3,7 +3,7 @@ This module contains the implementation of the `Domain` class.
 
 The `Domain` class represents the domain of the polynomials, i.e., the set of
 all input points for which the polynomials are defined. As the internals of
-Minterpy work for interpolating polynomial in the so-called "normalized"
+Minterpy work for interpolating polynomial in the so-called "internal"
 domain (i.e., :math:`[-1, 1]^m`), the class provides convenient methods for:
 
 - transformation of values to/from normalized domain in :math:`[-1, 1]^m`
@@ -17,7 +17,7 @@ import numpy as np
 
 from typing import Optional, Union
 
-from minterpy.global_settings import FLOAT_DTYPE
+from minterpy.global_settings import DEFAULT_DOMAIN, FLOAT_DTYPE
 from minterpy.utils.verification import verify_domain_bounds
 from minterpy.utils.exceptions import DomainMismatchError
 
@@ -39,26 +39,30 @@ class Domain:
     Parameters
     ----------
     bounds : np.ndarray
-        The domain bounds as a 2D array with shape (m, 2),
-        where m is the spatial dimension.
+        The domain bounds as a 2D array with shape ``(m, 2)``,
+        where ``m`` is the spatial dimension.
         The first column contains the lower bounds and the second column
         the upper bounds across dimensions.
     """
+    _INTERNAL_BOUNDS: np.ndarray = DEFAULT_DOMAIN
 
     def __init__(self, bounds: np.ndarray):
 
         # Verify and assign the bounds
         self._bounds = verify_domain_bounds(bounds)
 
+        # Assign internal bounds
+        self._internal_bounds = None  # Lazy evaluation
+
     # --- Factory methods
     @classmethod
     def uniform(
         cls,
         spatial_dimension: int,
-        lower_bound: float,
-        upper_bound: float,
+        lower: float,
+        upper: float,
     ):
-        """Create an instance of Domain with uniform bounds across dimensions.
+        r"""Create an instance with uniform bounds.
 
         Creates a hyper-rectangular domain :math:`[a, b]^m` where :math:`a`
         and :math:`b` are the lower and upper bounds for each dimension,
@@ -68,9 +72,9 @@ class Domain:
         ----------
         spatial_dimension : int
             The number of dimensions for the space.
-        lower_bound : float
+        lower : float
             The lower bound of each dimension.
-        upper_bound : float
+        upper : float
             The upper bound of each dimension.
 
         Returns
@@ -80,14 +84,16 @@ class Domain:
             bounds, i.e., the same lower and upper bound for all dimensions.
         """
         bounds = np.empty((spatial_dimension, 2), dtype=FLOAT_DTYPE)
-        bounds[:, 0] = lower_bound
-        bounds[:, 1] = upper_bound
+        bounds[:, 0] = lower
+        bounds[:, 1] = upper
 
         return cls(bounds)
 
     @classmethod
     def normalized(cls, spatial_dimension: int):
-        """Create an instance of Domain with [-1, 1] bound across dimensions.
+        r"""Create an instance with the default internal bounds.
+
+        The default internal bounds are :math:`[-1, 1]^m`.
 
         Parameters
         ----------
@@ -97,17 +103,16 @@ class Domain:
         Returns
         -------
         Domain
-            A new instance of the `Domain` class initialized with normalized
-            bounds, i.e., :math:`[-1, 1]^m` where :math:`m`
+            A new instance of the `Domain` class initialized with the default
+            internal bounds, i.e., :math:`[-1, 1]^m` where :math:`m`
             is the spatial dimension.
         """
-        bounds = np.empty((spatial_dimension, 2), dtype=FLOAT_DTYPE)
-        bounds[:, 0] = -1.0
-        bounds[:, 1] = 1.0
+        internal_bounds = cls._INTERNAL_BOUNDS[np.newaxis, :]
+        bounds = np.repeat(internal_bounds, spatial_dimension, axis=0)
 
         return cls(bounds)
 
-    # --- Properties
+    # --- Properties (public)
     @property
     def bounds(self) -> np.ndarray:
         """The domain bounds.
@@ -125,7 +130,7 @@ class Domain:
     @property
     def spatial_dimension(self):
         """Dimension of the domain space.
-        
+
         Return
         ------
         int
@@ -134,7 +139,7 @@ class Domain:
         return len(self.bounds)
 
     @property
-    def lower_bounds(self) -> np.ndarray:
+    def lowers(self) -> np.ndarray:
         """The lower bounds of the domain.
 
         Returns
@@ -146,7 +151,7 @@ class Domain:
         return self.bounds[:, 0]
 
     @property
-    def upper_bounds(self) -> np.ndarray:
+    def uppers(self) -> np.ndarray:
         """The upper bounds of the domain.
 
         Returns
@@ -158,7 +163,7 @@ class Domain:
         return self.bounds[:, 1]
 
     @property
-    def domain_widths(self) -> np.ndarray:
+    def widths(self) -> np.ndarray:
         """The widths of the domain.
 
         Returns
@@ -167,11 +172,11 @@ class Domain:
             The difference between the upper and lower bounds of the domain
             as a one-dimensional array having shape ``(m, )``.
         """
-        return self.upper_bounds - self.lower_bounds
+        return self.uppers - self.lowers
 
     @property
     def is_normalized(self) -> bool:
-        """Check whether the domain is normalized in :math:`[-1, 1]^m`.
+        """Check whether the domain is the same as the internal domain.
 
         Returns
         -------
@@ -187,15 +192,14 @@ class Domain:
         rtol = DEFAULT_RTOL
         atol = DEFAULT_ATOL
 
-        # Compute peak-to-peak width of the domain
-        lb = bool(np.isclose(self.lower_bounds, -1.0, rtol, atol).all())
-        ub = bool(np.isclose(self.upper_bounds, 1.0, rtol, atol).all())
+        lb = bool(np.allclose(self.lowers, self._internal_lowers, rtol, atol))
+        ub = bool(np.allclose(self.uppers, self._internal_uppers, rtol, atol))
 
         return lb and ub
 
     @property
     def is_uniform(self) -> bool:
-        """Check whether the domain is uniform.
+        r"""Check whether the domain is uniform.
 
         A uniform domain has the same lower and upper bounds in all dimensions,
         i.e., the domain has the form :math:`[a, b]^m` for some :math:`a`
@@ -212,6 +216,7 @@ class Domain:
           the bounds of the extra dimension from the bounds of the other
           dimensions.
         - A domain of dimension 1 is always uniform by definition.
+        - A normalized domain is always uniform, but not vice versa.
         - This check uses numerical tolerances (``DEFAULT_RTOL`` and
           ``DEFAULT_ATOL``) for robustness against floating-point errors.
         """
@@ -220,31 +225,86 @@ class Domain:
         atol = DEFAULT_ATOL
 
         # Lower bound condition
-        lb = self.lower_bounds[0]
-        lb_c = np.allclose(self.lower_bounds, lb, rtol=rtol, atol=atol)
+        lb_c = np.allclose(self.lowers, self.lowers[0], rtol=rtol, atol=atol)
 
         # Upper bound condition
-        ub = self.upper_bounds[0]
-        ub_c = np.allclose(self.upper_bounds, ub, rtol=rtol, atol=atol)
+        ub_c = np.allclose(self.uppers, self.uppers[0], rtol=rtol, atol=atol)
 
-        # Compute peak-to-peak width of the domain
-        ptp = np.ptp(self.domain_widths)
-        ptp_c = np.allclose(ptp, 0.0, rtol=rtol, atol=atol)
+        return bool(lb_c and ub_c)
 
-        return bool(lb_c and ub_c and ptp_c)
+    @property
+    def internal_bounds(self) -> np.ndarray:
+        """The bounds of the internal domain.
+
+        Returns
+        -------
+        np.ndarray
+            The bounds of the internal domain as a 2D array with shape
+            ``(m, 2)``, where ``m`` is the spatial dimension.
+            The first column contains the lower bounds and the second column
+            the upper bounds across dimensions.
+        """
+        if self._internal_bounds is None:
+            # Note: Use the default hard-coded internal bounds
+            self._internal_bounds = np.repeat(
+                self._INTERNAL_BOUNDS[np.newaxis, :],
+                self.spatial_dimension,
+                axis=0,
+            )
+
+        return self._internal_bounds
+
+    # --- Properties (private)
+    @property
+    def _internal_lowers(self) -> np.ndarray:
+        """The lower bounds of the internal domain.
+
+       Returns
+        -------
+        np.ndarray
+            The lower bounds of the internal domain as a one-dimensional array
+            having shape ``(m, )``.
+        """
+        return self.internal_bounds[:, 0]
+
+    @property
+    def _internal_uppers(self) -> np.ndarray:
+        """"The upper bounds of the internal domain.
+
+        Returns
+        -------
+        np.ndarray
+            The upper bounds of the internal domain as a one-dimensional array
+            having shape ``(m, )``.
+        """
+        return self.internal_bounds[:, 1]
+
+    @property
+    def _internal_widths(self) -> np.ndarray:
+        """"The widths of the internal domain.
+
+        Returns
+        -------
+        np.ndarray
+            The difference between the upper and lower bounds of the internal
+            domain as a one-dimensional array having shape ``(m, )``.
+        """
+        return self._internal_uppers - self._internal_lowers
 
     # --- Instance methods
-    def map_to_normalized(
+    def map_to_internal(
         self,
         xx: np.ndarray,
         validate: bool = False,
     ) -> np.ndarray:
-        """Map input points to normalized :math:`[-1, 1]^m` domain.
+        r"""Map input points to the internal domain.
+
+        The default internal domain is :math:`[-1, 1]^m`.
 
         Parameters
         ----------
         xx : :class:`numpy:numpy.ndarray`
-            The input points to be mapped to the normalized domain.
+            The input points to be mapped to the internal domain.
         validate : bool, optional
             If True, validate that input points are within domain bounds, i.e.,
             no extrapolation is allowed.
@@ -252,8 +312,8 @@ class Domain:
         Returns
         -------
         :class:`numpy:numpy.ndarray`
-            The normalized points in :math:`[-1, 1]^m` domain, except when
-            extrapolated (with ``validate=False``).
+            The points in the internal domain, except when extrapolated
+            (with ``validate=False``).
         """
         if validate and not np.all(self.contains(xx)):
             raise ValueError(
@@ -261,19 +321,24 @@ class Domain:
                 "Set validate=False to allow extrapolation."
             )
 
-        return -1 + 2 * (xx - self.lower_bounds) / self.domain_widths
+        ilb = self._internal_lowers
+        iwidths = self._internal_widths
 
-    def map_from_normalized(
+        return ilb + iwidths * (xx - self.lowers) / self.widths
+
+    def map_from_internal(
         self,
         xx: np.ndarray,
         validate: bool = False,
     ) -> np.ndarray:
-        """Map normalized points in :math:`[-1, 1]^m` to the original domain.
+        r"""Map points in the internal domain to the original domain.
+
+        The default internal domain is :math:`[-1, 1]^m`.
 
         Parameters
         ----------
         xx : :class:`numpy:numpy.ndarray`
-            The input points in the normalized domain to be mapped
+            The input points in the internal domain to be mapped
             to the original domain.
         validate : bool, optional
             If True, validate that input points are within domain bounds, i.e.,
@@ -284,13 +349,16 @@ class Domain:
         :class:`numpy:numpy.ndarray`
             The points in the original domain.
         """
-        if validate and not np.all((xx <= 1.0) & (xx >= -1.0)):
+        if validate and not np.all(self.contains(xx, internal=True)):
             raise ValueError(
-                "Input points are outside of [-1, 1]^m domain. "
+                "Input points are outside of the internal domain. "
                 "Set validate=False to allow extrapolation."
             )
 
-        return self.lower_bounds + (xx + 1) / 2 * self.domain_widths
+        ilb = self._internal_lowers
+        iwidths = self._internal_widths
+
+        return self.lowers + (xx - ilb) / iwidths * self.widths
 
     def get_int_factor(self) -> float:
         """Compute the scaling factor for polynomial integration.
@@ -305,7 +373,7 @@ class Domain:
         - Here, we assume that the integration is carried out over all
           dimensions.
         """
-        return float(np.prod(self.domain_widths / 2.0))
+        return float(np.prod(self.widths / self._internal_widths))
 
     def get_diff_factor(self, order: np.ndarray) -> float:
         """Compute the scaling factor for polynomial differentiation.
@@ -323,8 +391,9 @@ class Domain:
             The scaling factor for polynomial differentiation.
         """
         idx = order > 0
+        iwidths = self._internal_widths
 
-        return float(np.prod((2.0 / self.domain_widths[idx])**(order[idx])))
+        return float(np.prod((iwidths[idx] / self.widths[idx])**(order[idx])))
 
     def partial_matching(
         self,
@@ -364,20 +433,35 @@ class Domain:
 
         dim = min(self.spatial_dimension, other.spatial_dimension)
 
-        return np.allclose(
+        # "User" bounds
+        bounds_match = np.allclose(
             self.bounds[:dim, :],
             other.bounds[:dim, :],
             rtol=rtol,
             atol=atol,
         )
 
-    def contains(self, xx: np.ndarray) -> np.ndarray:
+        # Check internal bounds (currently identical for all instances,
+        # but enables future generalization of internal coordinate system)
+        internal_bounds_match = np.allclose(
+            self.internal_bounds[:dim, :],
+            other.internal_bounds[:dim, :],
+            rtol=rtol,
+            atol=atol,
+        )
+
+        return bool(bounds_match and internal_bounds_match)
+
+    def contains(self, xx: np.ndarray, internal: bool = False) -> np.ndarray:
         """Check whether the input points are contained in the domain.
 
         Parameters
         ----------
         xx : :class:`numpy:numpy.ndarray`
             A set of values to be checked.
+        internal : bool, optional
+            Check against internal bounds instead of the domain bounds.
+            The default is ``False``.
 
         Returns
         -------
@@ -385,10 +469,14 @@ class Domain:
             A boolean array indicating whether each point is contained
             in the domain.
         """
-        return (
-                np.all(self.lower_bounds <= xx, axis=1)
-                & np.all(xx <= self.upper_bounds, axis=1)
-        )
+        if internal:
+            lb = self._internal_lowers
+            ub = self._internal_uppers
+        else:
+            lb = self.lowers
+            ub = self.uppers
+
+        return np.all(lb <= xx, axis=1) & np.all(xx <= ub, axis=1)
 
     def expand_dim(self, target: Union[int, "Domain"]) -> "Domain":
         """Expand the dimension of the domain.
@@ -436,8 +524,8 @@ class Domain:
                     "bounds for the extra dimension."
                 )
 
-            lb = self.lower_bounds[0]
-            ub = self.upper_bounds[0]
+            lb = self.lowers[0]
+            ub = self.uppers[0]
 
             return self.__class__.uniform(target, lb, ub)
 
@@ -491,7 +579,13 @@ class Domain:
         if not isinstance(other, Domain):
             return False
 
-        return np.array_equal(self.bounds, other.bounds)
+        bounds_eq = np.array_equal(self.bounds, other.bounds)
+        internal_bounds_eq = np.array_equal(
+            self.internal_bounds,
+            other.internal_bounds,
+        )
+
+        return bool(bounds_eq and internal_bounds_eq)
 
     def __or__(self, other: "Domain") -> "Domain":
         """Combine two instances of Domain via the ``|`` operator.

--- a/src/minterpy/core/grid.py
+++ b/src/minterpy/core/grid.py
@@ -73,7 +73,6 @@ from minterpy.utils.verification import (
     check_type,
     check_values,
     check_dimensionality,
-    check_domain_fit,
 )
 
 __all__ = ["Grid"]
@@ -154,6 +153,12 @@ class Grid:
         # Process and assign the multi-index set argument
         self._multi_index = _process_multi_index(multi_index)
 
+        # Process and assign the domain
+        if domain is None:
+            domain = Domain.normalized(self.multi_index.spatial_dimension)
+
+        self._domain = _process_domain(domain, multi_index)
+
         # If generating_function and points not specified,
         # use the default generating function
         no_gen_function = generating_function is None
@@ -167,19 +172,15 @@ class Grid:
         )
 
         # Assign and verify the generating points argument
+        # Note: Domain is already processed
         if no_gen_points:
             generating_points = self._create_generating_points()
         else:
             # Create a copy to avoid accidental changes from the outside
             generating_points = generating_points.copy()
-        self._generating_points = generating_points
-        self._verify_generating_points()
-
-        # Process and assign the domain
-        if domain is None:
-            domain = Domain.normalized(self.multi_index.spatial_dimension)
-
-        self._domain = _process_domain(domain, multi_index)
+        self._generating_points = self._verify_generating_points(
+            generating_points
+        )
 
         # --- Post-assignment verifications
 
@@ -860,7 +861,7 @@ class Grid:
         if self.domain.is_normalized:
             xx = self.unisolvent_nodes
         else:
-            xx = self.domain.map_from_normalized(self.unisolvent_nodes)
+            xx = self.domain.map_from_internal(self.unisolvent_nodes)
         return fun(xx, *args, **kwargs)
 
     # --- Dunder methods: Rich comparison
@@ -1126,38 +1127,69 @@ class Grid:
         """
         return self.generating_function is not None
 
-    def _verify_generating_points(self):
-        """Verify if the generating points are valid.
+    def _verify_generating_points(
+        self,
+        generating_points: np.ndarray,
+    ) -> np.ndarray:
+        """Validate generating points.
+
+        Parameters
+        ----------
+        generating_points : np.ndarray
+            The given generating points to validate, a 2D array of
+            shape ``(n + 1, m)`` where ``n`` is the maximum degree of the
+            the grid in any dimension and ``m`` is the maximum spatial
+            dimension of the grid.
+
+        Returns
+        -------
+        np.ndarray
+            Validated generating points.
 
         Raises
         ------
         ValueError
-            If the points are not of the correct dimension, contains
-            NaN's or inf's, do not fit the standard domain, or the values
-            per column are not unique.
+            If the points are not of the correct dimension, contain
+            NaN's or inf's, do not match with the dimension of the grid,
+            the values per column are not unique, or the points are not
+            within the internal domain.
         TypeError
             If the points are not given in the correct type.
+
+        Notes
+        -----
+        - Generating points may contain more columns (i.e., spatial dimension)
+          than the grid itself (as defined by the dimension of the multi-index
+          set). If there's no generating function, this indicates the maximum
+          dimension the current grid can be expanded to.
         """
-        # Check array dimension
-        check_dimensionality(self._generating_points, dimensionality=2)
-        # No NaN's and inf's
-        check_values(self._generating_points)
-        # Check domain fit
-        check_domain_fit(self._generating_points)
-        # Check dimension against spatial dimension of the set
-        gen_points_dim = self._generating_points.shape[1]
+        # --- Type and structure checks
+        check_type(generating_points, np.ndarray)
+        check_dimensionality(generating_points, dimensionality=2)
+        check_values(generating_points)  # No NaN's and inf's
+
+        # --- Dimension check
+        gen_points_dim = generating_points.shape[1]
         if gen_points_dim < self.spatial_dimension:
             raise ValueError(
-                "Dimension mismatch between the generating points "
-                f"({gen_points_dim}) and the multi-index set "
-                f"({self.spatial_dimension})"
+                "Dimension mismatch between generating points "
+                f"({gen_points_dim}) and the grid ({self.spatial_dimension})"
             )
-        # Check the uniqueness of values column-wise
-        are_unique = all([is_unique(xx) for xx in self._generating_points.T])
-        if not are_unique:
+
+        # --- Uniqueness check (column-wise)
+        if not all(is_unique(col) for col in generating_points.T):
             raise ValueError(
                 "One or more columns of the generating points are not unique"
             )
+
+        # --- Internal domain containment check
+        gen_points_ = generating_points[:, :self.spatial_dimension]
+        if not np.all(self.domain.contains(gen_points_, internal=True)):
+            raise ValueError(
+                "Generating points are not contained in the internal domain"
+            )
+
+        return generating_points
 
     def _verify_matching_gen_function_and_points(self):
         """Verify if the generation function and points match.

--- a/src/minterpy/global_settings.py
+++ b/src/minterpy/global_settings.py
@@ -15,7 +15,7 @@ INT_DTYPE = np.int_
 FLOAT_DTYPE = np.float64  # NOTE: numpy.float_ is deprecated in NumPy v2.0
 B_DTYPE = np.bool_
 
-DEFAULT_DOMAIN = np.array([-1, 1])
+DEFAULT_DOMAIN = np.array([-1, 1], dtype=FLOAT_DTYPE)
 
 # --- Numba types. Must match the Numpy dtypes
 

--- a/src/minterpy/polynomials/canonical_polynomial.py
+++ b/src/minterpy/polynomials/canonical_polynomial.py
@@ -22,10 +22,7 @@ from minterpy.utils.polynomials.interface import (
     PolyData,
     scalar_add_via_monomials,
 )
-from minterpy.utils.verification import (
-    dummy,
-    verify_domain,
-)
+from minterpy.utils.verification import dummy
 from minterpy.utils.arrays import make_coeffs_2d
 from minterpy.utils.multi_index import find_match_between
 from minterpy.jit_compiled.multi_index import all_indices_are_contained
@@ -144,11 +141,6 @@ def mul_canonical(
     return CanonicalPolynomial(**poly_prod_data._asdict())
 
 
-# TODO redundant
-canonical_generate_internal_domain = verify_domain
-canonical_generate_user_domain = verify_domain
-
-
 def _canonical_partial_diff(poly: "CanonicalPolynomial", dim: int, order: int) -> "CanonicalPolynomial":
     """ Partial differentiation in Canonical basis.
     """
@@ -240,10 +232,6 @@ class CanonicalPolynomial(MultivariatePolynomialSingleABC):
     _diff = staticmethod(_canonical_diff)
     _integrate_over = staticmethod(_canonical_integrate_over)
 
-    # Domain generation
-    generate_internal_domain = staticmethod(canonical_generate_internal_domain)
-    generate_user_domain = staticmethod(canonical_generate_user_domain)
-
 
 # --- Internal utility functions
 def _compute_data_poly_sum(
@@ -291,8 +279,8 @@ def _compute_data_poly_sum(
     return PolyData(
         multi_index=mi_sum,
         coeffs=coeffs_sum,
-        internal_domain=internal_domain_sum,
-        user_domain=user_domain_sum,
+        # internal_domain=internal_domain_sum,
+        # user_domain=user_domain_sum,
         grid=grd_sum,
     )
 
@@ -339,18 +327,7 @@ def _compute_data_poly_prod(
         mi_prod,
     )
 
-    # --- Process the domains
-    # Deprecate: the properties will be removed in the future
-    internal_domain_prod = grd_prod.domain.bounds.T
-    user_domain_prod = grd_prod.domain.bounds.T
-
-    return PolyData(
-        multi_index=mi_prod,
-        coeffs=coeffs_prod,
-        internal_domain=internal_domain_prod,
-        user_domain=user_domain_prod,
-        grid=grd_prod,
-    )
+    return PolyData(multi_index=mi_prod, coeffs=coeffs_prod, grid=grd_prod)
 
 
 def _compute_quad_weights(

--- a/src/minterpy/polynomials/chebyshev_polynomial.py
+++ b/src/minterpy/polynomials/chebyshev_polynomial.py
@@ -28,7 +28,7 @@ from minterpy.utils.polynomials.interface import (
     scalar_add_via_monomials,
     select_active_monomials,
 )
-from minterpy.utils.verification import dummy, verify_domain
+from minterpy.utils.verification import dummy
 from minterpy.services import is_scalar
 
 
@@ -171,10 +171,6 @@ class ChebyshevPolynomial(MultivariatePolynomialSingleABC):
     _diff = staticmethod(dummy)  # type: ignore
     _integrate_over = staticmethod(dummy)  # type: ignore
 
-    # Domain generation
-    generate_internal_domain = staticmethod(verify_domain)
-    generate_user_domain = staticmethod(verify_domain)
-
 
 # --- Internal utility functions
 def _compute_data_poly_sum(
@@ -216,18 +212,7 @@ def _compute_data_poly_sum(
     #       instead of the one attached to grid
     coeffs_sum = compute_coeffs_poly_sum_via_monomials(poly_1, poly_2, mi_sum)
 
-    # --- Process the domains
-    # Deprecate: the properties will be removed in the future
-    internal_domain_sum = grd_sum.domain.bounds.T
-    user_domain_sum = grd_sum.domain.bounds.T
-
-    return PolyData(
-        mi_sum,
-        coeffs_sum,
-        internal_domain_sum,
-        user_domain_sum,
-        grd_sum,
-    )
+    return PolyData(mi_sum, coeffs_sum, grd_sum)
 
 
 def _compute_data_poly_prod(
@@ -262,18 +247,7 @@ def _compute_data_poly_prod(
     #       instead of the one attached to grid
     coeffs_prod = _compute_coeffs_poly_prod(poly_1, poly_2, grd_prod, mi_prod)
 
-    # --- Process the domains
-    # Deprecate: the properties will be removed in the future
-    internal_domain_prod = grd_prod.domain.bounds.T
-    user_domain_prod = grd_prod.domain.bounds.T
-
-    return PolyData(
-        multi_index=mi_prod,
-        coeffs=coeffs_prod,
-        internal_domain=internal_domain_prod,
-        user_domain=user_domain_prod,
-        grid=grd_prod,
-    )
+    return PolyData(multi_index=mi_prod, coeffs=coeffs_prod, grid=grd_prod)
 
 
 def _compute_coeffs_poly_prod(

--- a/src/minterpy/polynomials/lagrange_polynomial.py
+++ b/src/minterpy/polynomials/lagrange_polynomial.py
@@ -41,7 +41,7 @@ import numpy as np
 from minterpy.global_settings import SCALAR
 from minterpy.core.ABC import MultivariatePolynomialSingleABC
 from minterpy.utils.polynomials.lagrange import integrate_monomials_lagrange
-from minterpy.utils.verification import dummy, verify_domain
+from minterpy.utils.verification import dummy
 
 __all__ = ["LagrangePolynomial"]
 
@@ -103,11 +103,6 @@ def integrate_over_lagrange(
     return quad_weights @ poly.coeffs
 
 
-# TODO redundant
-lagrange_generate_internal_domain = verify_domain
-lagrange_generate_user_domain = verify_domain
-
-
 class LagrangePolynomial(MultivariatePolynomialSingleABC):
     """Concrete implementation of polynomials in the Lagrange basis.
 
@@ -149,10 +144,6 @@ class LagrangePolynomial(MultivariatePolynomialSingleABC):
     _partial_diff = staticmethod(dummy)  # type: ignore
     _diff = staticmethod(dummy)  # type: ignore
     _integrate_over = staticmethod(integrate_over_lagrange)
-
-    # Domain generation
-    generate_internal_domain = staticmethod(lagrange_generate_internal_domain)
-    generate_user_domain = staticmethod(lagrange_generate_user_domain)
 
 
 # --- Internal utility functions

--- a/src/minterpy/polynomials/newton_polynomial.py
+++ b/src/minterpy/polynomials/newton_polynomial.py
@@ -734,6 +734,18 @@ def _is_compute_coeffs_poly_prod_via_monomials(
 ) -> bool:
     """Check if the polynomials may be multiplied via the monomials.
 
+    The multiplication can use the monomial approach when the resulting Newton
+    polynomial lives on the same grid (with the same generating points) as one
+    of the operands. This allows reusing the existing Newton basis without
+    recomputation, which is crucial since changing the degree typically alters
+    the generating points for unnested grids (e.g., Chebyshev-Lobatto).
+
+    Because Newton polynomials are not closed under multiplication (i.e., the
+    product of two Newton basis polynomials is not itself a Newton basis
+    polynomial of higher degree), at least one operand must be a scalar
+    polynomial to ensure that the product can be represented
+    in the same Newton basis as the non-scalar operand.
+
     Parameters
     ----------
     poly_1 : NewtonPolynomial
@@ -750,18 +762,67 @@ def _is_compute_coeffs_poly_prod_via_monomials(
         one of them has a scalar monomial and both of the underlying grids are
         compatible with the given product grid; ``False`` otherwise.
     """
-    # Check if one of the operands is a scalar polynomial
+    # Check if either operand is a strictly scalar polynomial
     is_scalar_poly = is_scalar(poly_1) or is_scalar(poly_2)
-    # Check if one of the monomials of the operand is a scalar
-    is_scalar_multi_index_1 = is_scalar(poly_1.multi_index)
-    is_scalar_multi_index_2 = is_scalar(poly_2.multi_index)
-    is_scalar_multi_index = is_scalar_multi_index_1 or is_scalar_multi_index_2
-    # Check if the grids are compatible with the given grid
-    is_compatible_grid_1 = poly_1.grid.is_compatible(grid_prod)
-    is_compatible_grid_2 = poly_2.grid.is_compatible(grid_prod)
-    is_compatible_grids = is_compatible_grid_1 and is_compatible_grid_2
 
-    return is_scalar_poly or (is_scalar_multi_index and is_compatible_grids)
+    # Check grid compatibility based on scalar multi_index
+    poly_1_scalar_idx = is_scalar(poly_1.multi_index)
+    poly_2_scalar_idx = is_scalar(poly_2.multi_index)
+
+    if poly_1_scalar_idx and poly_2_scalar_idx:
+        # Both have scalar multi_index: always compatible
+        grid_compatible = True
+    elif poly_1_scalar_idx:
+        # Only poly_1 has scalar multi_index: check poly_2's grid
+        grid_compatible = poly_2.grid.has_compatible_gen_points(grid_prod)
+    elif poly_2_scalar_idx:
+        # Only poly_2 has scalar multi_index: check poly_1's grid
+        grid_compatible = poly_1.grid.has_compatible_gen_points(grid_prod)
+    else:
+        # Neither has scalar multi_index: not compatible
+        grid_compatible = False
+
+    # Compatible if either operand is scalar OR grids are compatible
+    return is_scalar_poly or grid_compatible
+
+    # # Check if one of the operands is a scalar polynomial
+    # is_scalar_poly = is_scalar(poly_1) or is_scalar(poly_2)
+    #
+    # # Check if one of the monomials of the operand is a scalar
+    # is_scalar_multi_index_1 = is_scalar(poly_1.multi_index)
+    # is_scalar_multi_index_2 = is_scalar(poly_2.multi_index)
+    # is_scalar_multi_index = is_scalar_multi_index_1 or is_scalar_multi_index_2
+    # # Check if the grids are compatible with the given grid
+    # is_compatible_grid_1 = poly_1.grid.has_compatible_gen_points(grid_prod)
+    # is_compatible_grid_2 = poly_2.grid.has_compatible_gen_points(grid_prod)
+    # is_compatible_grids = is_compatible_grid_1 and is_compatible_grid_2
+    #
+    # # If either of the conditions is true then the resulting Newton polynomial
+    # # has exactly the same basis as the non scalar one.
+    # # return is_scalar_poly or (is_scalar_multi_index and is_compatible_grids)
+    #
+    # # if is_scalar(poly_1.multi_index):
+    # #     cond_1 = True
+    # # else:
+    # #     cond_1 = poly_1.grid.has_compatible_gen_points(grid_prod)
+    # #
+    # # if is_scalar(poly_2.multi_index):
+    # #     cond_2 = True
+    # # else:
+    # #     cond_2 = poly_2.grid.has_compatible_gen_points(grid_prod)
+    #
+    # if is_scalar(poly_1.multi_index):
+    #     if is_scalar(poly_2.multi_index):
+    #         cond = True
+    #     else:
+    #         cond = poly_2.grid.has_compatible_gen_points(grid_prod)
+    # else:
+    #     if is_scalar(poly_2.multi_index):
+    #         cond = poly_1.grid.has_compatible_gen_points(grid_prod)
+    #     else:
+    #         cond = False
+    #
+    # return is_scalar_poly or cond #(cond_1 and cond_2)
 
 
 def _compute_coeffs_poly_prod_via_lagrange(

--- a/src/minterpy/polynomials/newton_polynomial.py
+++ b/src/minterpy/polynomials/newton_polynomial.py
@@ -44,7 +44,7 @@ from minterpy.core.ABC.multivariate_polynomial_abstract import (
 )
 from minterpy.core import Grid, MultiIndexSet
 from minterpy.dds import dds
-from minterpy.utils.verification import dummy, verify_domain
+from minterpy.utils.verification import dummy
 from minterpy.utils.polynomials.newton import (
     eval_newton_polynomials,
     deriv_newt_eval as eval_diff_numpy,
@@ -371,11 +371,6 @@ def integrate_over_newton(
     return quad_weights @ poly.coeffs
 
 
-# TODO redundant
-generate_internal_domain_newton = verify_domain
-generate_user_domain_newton = verify_domain
-
-
 class NewtonPolynomial(MultivariatePolynomialSingleABC):
     """Concrete implementations of polynomials in the Newton basis.
 
@@ -401,10 +396,6 @@ class NewtonPolynomial(MultivariatePolynomialSingleABC):
     _partial_diff = staticmethod(partial_diff_newton)
     _diff = staticmethod(diff_newton)
     _integrate_over = staticmethod(integrate_over_newton)
-
-    # Domain generation
-    generate_internal_domain = staticmethod(generate_internal_domain_newton)
-    generate_user_domain = staticmethod(generate_user_domain_newton)
 
 
 # --- Internal utility functions
@@ -448,18 +439,7 @@ def _compute_data_poly_sum(
     # --- Process the coefficients
     coeffs_sum = _compute_coeffs_poly_sum(poly_1, poly_2, grd_sum, mi_sum)
 
-    # --- Process the domains
-    # Deprecate: the properties will be removed in the future
-    internal_domain_sum = grd_sum.domain.bounds.T
-    user_domain_sum = grd_sum.domain.bounds.T
-
-    return PolyData(
-        multi_index=mi_sum,
-        coeffs=coeffs_sum,
-        internal_domain=internal_domain_sum,
-        user_domain=user_domain_sum,
-        grid=grd_sum,
-    )
+    return PolyData(multi_index=mi_sum, coeffs=coeffs_sum, grid=grd_sum)
 
 
 def _compute_coeffs_poly_sum(
@@ -649,18 +629,7 @@ def _compute_data_poly_prod(
     # --- Process the coefficients
     coeffs_prod = _compute_coeffs_poly_prod(poly_1, poly_2, grd_prod, mi_prod)
 
-    # --- Process the domains
-    # Deprecate: the properties will be removed in the future
-    internal_domain_prod = grd_prod.domain.bounds.T
-    user_domain_prod = grd_prod.domain.bounds.T
-
-    return PolyData(
-        multi_index=mi_prod,
-        coeffs=coeffs_prod,
-        internal_domain=internal_domain_prod,
-        user_domain=user_domain_prod,
-        grid=grd_prod,
-    )
+    return PolyData(multi_index=mi_prod, coeffs=coeffs_prod, grid=grd_prod)
 
 
 def _compute_coeffs_poly_prod(

--- a/src/minterpy/utils/polynomials/interface.py
+++ b/src/minterpy/utils/polynomials/interface.py
@@ -22,8 +22,6 @@ class PolyData(NamedTuple):
     """Container for complete inputs to create a polynomial in any basis."""
     multi_index: MultiIndexSet
     coeffs: np.ndarray
-    internal_domain: np.ndarray
-    user_domain: np.ndarray
     grid: Grid
 
 
@@ -377,7 +375,12 @@ def _create_scalar_poly(
     # Create a Grid
     # The grid of the polynomial may not include the multi-index set element
     # (0, ..., 0) (i.e., it's non-downward-closed) so create a new one.
-    grd = Grid(mi, poly.grid.generating_function, poly.grid.generating_points)
+    grd = Grid(
+        mi,
+        poly.grid.generating_function,
+        poly.grid.generating_points,
+        domain=poly.grid.domain,
+    )
 
     # Create the coefficient
     if len(poly) == 1:
@@ -389,13 +392,7 @@ def _create_scalar_poly(
         )
 
     # Return a polynomial instance of the same class as input
-    return poly.__class__(
-        multi_index=mi,
-        coeffs=coeffs,
-        internal_domain=poly.internal_domain,
-        user_domain=poly.user_domain,
-        grid=grd,
-    )
+    return poly.__class__(multi_index=mi, coeffs=coeffs, grid=grd)
 
 
 def _match_mi_dim(mi_1: MultiIndexSet, mi_2: MultiIndexSet) -> MultiIndexSet:

--- a/src/minterpy/utils/verification.py
+++ b/src/minterpy/utils/verification.py
@@ -20,32 +20,6 @@ from minterpy.utils.exceptions import (
 )
 
 
-def verify_domain(domain, spatial_dimension):
-    """Building and verification of domains.
-
-    This function builds a suitable domain as the cartesian product of a one-
-    dimensional domain, or verifies the domain shape, of a multivariate domain is
-    passed. If None is passed, the default domain is build from [-1,1].
-
-    :param domain: Either one-dimensional domain ``(min,max)``, or a stack of domains for each domain with shape ``(spatial_dimension,2)``. If :class:`None` is passed, the ``DEFAULT_DOMAIN`` is repeated for each spatial dimentsion.
-    :type domain: array_like, None
-    :param spatial_dimension: Dimentsion of the domain space.
-    :type spatial_dimension: int
-
-    :return verified_domain: Stack of domains for each dimension with shape ``(spatial_dimension,2)``.
-    :rtype: np.ndarray
-    :raise ValueError: If no domain with the expected shape can be constructed from the input.
-
-    """
-    if domain is None:
-        domain = np.repeat(DEFAULT_DOMAIN[:, np.newaxis], spatial_dimension, axis=1)
-    domain = np.require(domain, dtype=FLOAT_DTYPE)
-    if domain.ndim == 1:
-        domain = np.repeat(domain[:, np.newaxis], spatial_dimension, axis=1)
-    check_shape(domain, shape=(2, spatial_dimension))
-    return domain
-
-
 def check_type(obj: Any, expected_type: Type[Any]):
     """Check if the given input is of expected type.
     

--- a/src/minterpy/utils/verification.py
+++ b/src/minterpy/utils/verification.py
@@ -256,58 +256,6 @@ def check_values(xx: Union[int, float, np.ndarray], **kwargs):
         )
 
 
-DOMAIN_WARN_MSG2 = "the grid points must fit the interpolation domain [-1;1]^m."
-DOMAIN_WARN_MSG = (
-    "this may lead to unexpected behaviour, "
-    "e.g. rank deficiencies in the regression matrices, etc. ."
-)
-
-
-def check_domain_fit(points: np.ndarray):
-    """Checks weather a given array of points is properly formatted and spans the standard domain :math:`[-1,1]^m`.
-
-    .. todo::
-        - maybe remove the warnings.
-        - generalise to custom ``internal_domain``
-
-    :param points: array to be checked. Here ``m`` is the dimenstion of the domain and ``k`` is the number of points.
-    :type points: np.ndarray, shape = (m, k)
-    :raises ValueError: if the grid points do not fit into the domain :math:`[-1;1]^m`.
-    :raises ValueError: if less than one point is passed.
-
-    """
-    # check first if the sample points are valid
-    check_type(points, np.ndarray)
-    check_values(points)
-    # check weather the points lie outside of the domain
-    sample_max = np.max(points, axis=1)
-    if not np.allclose(np.maximum(sample_max, 1.0), 1.0):
-        raise ValueError(DOMAIN_WARN_MSG2 + f"violated max: {sample_max}")
-    sample_min = np.min(points, axis=1)
-    if not np.allclose(np.minimum(sample_min, -1.0), -1.0):
-        raise ValueError(DOMAIN_WARN_MSG2 + f"violated min: {sample_min}")
-    check_dimensionality(points, dimensionality=2)
-    nr_of_points, m = points.shape
-    if nr_of_points == 0:
-        raise ValueError("at least one point must be given")
-    if nr_of_points == 1:
-        return  # one point cannot span the domain
-    if DEBUG:
-        # check weather the points span the hole domain
-        max_grid_val = np.max(sample_max)
-        if not np.isclose(max_grid_val, 1.0):
-            warn(
-                f"the highest encountered value in the given points is {max_grid_val}  (expected 1.0). "
-                + DOMAIN_WARN_MSG
-            )
-        min_grid_val = np.min(sample_min)
-        if not np.isclose(min_grid_val, -1.0):
-            warn(
-                f"the smallest encountered value in the given points is {min_grid_val} (expected -1.0). "
-                + DOMAIN_WARN_MSG
-            )
-
-
 def is_real_scalar(x: Union[int, float, np.integer, np.floating]) -> bool:
     """Check if a given value is a real scalar number.
 

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from minterpy import Domain
+from minterpy.global_settings import DEFAULT_DOMAIN
 from minterpy.utils.exceptions import (
     DomainMismatchError,
     InvalidDomainBoundsError,
@@ -138,25 +139,25 @@ class TestProperties:
 
     def test_lower_bounds(self, random_bounds_valid):
         """Test the lower bounds property."""
-        my_dom = Domain(random_bounds_valid)
+        dom = Domain(random_bounds_valid)
 
         # Assertion
-        assert np.all(my_dom.lower_bounds == random_bounds_valid[:, 0])
+        assert np.all(dom.lowers == random_bounds_valid[:, 0])
 
     def test_upper_bounds(self, random_bounds_valid):
         """Test the upper bounds property."""
-        my_dom = Domain(random_bounds_valid)
+        dom = Domain(random_bounds_valid)
 
         # Assertion
-        assert np.all(my_dom.upper_bounds == random_bounds_valid[:, 1])
+        assert np.all(dom.uppers == random_bounds_valid[:, 1])
 
     def test_domain_widths(self, random_bounds_valid):
         """Test the domain widths property."""
-        my_dom = Domain(random_bounds_valid)
+        dom = Domain(random_bounds_valid)
 
         # Assertion
         diff_bounds = random_bounds_valid[:, 1] - random_bounds_valid[:, 0]
-        assert np.all(my_dom.domain_widths == diff_bounds)
+        assert np.all(dom.widths == diff_bounds)
 
     def test_normalized(self, SpatialDimension):
         """Test the normalized property for normalized domain."""
@@ -210,11 +211,11 @@ class TestMapValues:
 
     def test_to_normalized_edges(self, random_bounds_valid):
         """"Test the mapping of the edges to the normalized domain."""
-        my_dom = Domain(random_bounds_valid)
+        dom = Domain(random_bounds_valid)
 
         # Generate values at the edge of the domain
-        xx = np.c_[my_dom.lower_bounds, my_dom.upper_bounds].T
-        yy = my_dom.map_to_normalized(xx)
+        xx = np.c_[dom.lowers, dom.uppers].T
+        yy = dom.map_to_internal(xx)
 
         # Assertions
         assert np.allclose(yy[0], -1.0)
@@ -222,82 +223,84 @@ class TestMapValues:
 
     def test_from_normalized_edges(self, random_bounds_valid):
         """"Test the mapping of the edges from the normalized domain."""
-        my_dom = Domain(random_bounds_valid)
+        dom = Domain(random_bounds_valid)
 
         # Generate values at the edge of the normalized domain
-        dim = my_dom.spatial_dimension
+        dim = dom.spatial_dimension
         xx = np.c_[-1 * np.ones(dim), np.ones(dim)].T
-        yy = my_dom.map_from_normalized(xx)
+        yy = dom.map_from_internal(xx)
 
         # Assertions
-        assert np.allclose(yy[0], my_dom.lower_bounds)
-        assert np.allclose(yy[1], my_dom.upper_bounds)
+        assert np.allclose(yy[0], dom.lowers)
+        assert np.allclose(yy[1], dom.uppers)
 
     def test_to_normalized_extrapolation(self, random_bounds_valid):
         """Test that extrapolation to normalized domain is correctly handled."""
-        my_dom = Domain(random_bounds_valid)
+        dom = Domain(random_bounds_valid)
 
         # Generate out of bounds values in the original domain
         xx = generate_values_outbounds(random_bounds_valid)
-        yy = my_dom.map_to_normalized(xx)
+        yy = dom.map_to_internal(xx)
 
         # Assertion
-        assert np.any(yy <= -1.) or np.any(yy >= 1.)
+        default_lb, default_ub = DEFAULT_DOMAIN
+        assert np.any(yy <= default_lb) or np.any(yy >= default_ub)
 
     def test_from_normalized_extrapolation(self, random_bounds_valid):
         """Test that extrapolation from normalized domain is correctly handled.
         """
-        my_dom = Domain(random_bounds_valid)
+        dom = Domain(random_bounds_valid)
 
         # Generate out of bounds values in the normalized domain
-        bounds = np.ones((my_dom.spatial_dimension, 2))
+        bounds = np.ones((dom.spatial_dimension, 2))
         bounds[:, 0] = -1
         xx = generate_values_outbounds(bounds)
-        yy = my_dom.map_from_normalized(xx)
+        yy = dom.map_from_internal(xx)
 
         # Assertion
-        lb, ub = my_dom.lower_bounds, my_dom.upper_bounds
+        lb, ub = dom.lowers, dom.uppers
         assert np.any(yy <= lb) or np.any(yy >= ub)
 
     def test_to_normalized_valid(self, random_bounds_valid):
         """Test transformation to the normalized domain with valid values."""
-        my_dom = Domain(random_bounds_valid)
+        dom = Domain(random_bounds_valid)
 
         # Generate random valid input values
         xx = generate_values_inbounds(random_bounds_valid)
         # All the same for valid input values
-        yy_1 = my_dom.map_to_normalized(xx)
-        yy_2 = my_dom.map_to_normalized(xx, validate=True)
-        yy_3 = my_dom.map_to_normalized(xx, validate=False)
+        yy_1 = dom.map_to_internal(xx)
+        yy_2 = dom.map_to_internal(xx, validate=True)
+        yy_3 = dom.map_to_internal(xx, validate=False)
 
         # Assertion
-        assert np.all(yy_1 >= -1.) and np.all(yy_1 <= 1.)
-        assert np.all(yy_2 >= -1.) and np.all(yy_2 <= 1.)
-        assert np.all(yy_3 >= -1.) and np.all(yy_3 <= 1.)
+        default_lb, default_ub = DEFAULT_DOMAIN
+        assert np.all(yy_1 >= default_lb) and np.all(yy_1 <= default_ub)
+        assert np.all(yy_2 >= default_lb) and np.all(yy_2 <= default_ub)
+        assert np.all(yy_3 >= default_lb) and np.all(yy_3 <= default_ub)
 
     def test_to_normalized_invalid(self, random_bounds_valid):
         """Test transformation to the normalized domain with invalid values."""
-        my_dom = Domain(random_bounds_valid)
+        dom = Domain(random_bounds_valid)
 
         # Generate random invalid input values
         xx = generate_values_outbounds(random_bounds_valid)
 
         with pytest.raises(ValueError):
-            _ = my_dom.map_to_normalized(xx, validate=True)
+            _ = dom.map_to_internal(xx, validate=True)
 
-    def test_from_normalized_valid(self, random_bounds_valid):
-        """Test transformation from the normalized domain with valid values."""
-        my_dom = Domain(random_bounds_valid)
+    def test_from_internal_valid(self, random_bounds_valid):
+        """Test transformation from the internal domain with valid values."""
+        dom = Domain(random_bounds_valid)
 
         # Generate random valid input values in the normalized domain
-        xx = -1 + 2 * np.random.rand(10, my_dom.spatial_dimension)
+        xx = -1 + 2 * np.random.rand(10, dom.spatial_dimension)
         # All the same for valid input values
-        yy_1 = my_dom.map_from_normalized(xx)
-        yy_2 = my_dom.map_from_normalized(xx, validate=True)
-        yy_3 = my_dom.map_from_normalized(xx, validate=False)
+        yy_1 = dom.map_from_internal(xx)
+        yy_2 = dom.map_from_internal(xx, validate=True)
+        yy_3 = dom.map_from_internal(xx, validate=False)
 
         # Assertion
-        lb, ub = my_dom.lower_bounds, my_dom.upper_bounds
+        lb, ub = dom.lowers, dom.uppers
         assert np.all(yy_1 >= lb) and np.all(yy_1 <= ub)
         assert np.all(yy_2 >= lb) and np.all(yy_2 <= ub)
         assert np.all(yy_3 >= lb) and np.all(yy_3 <= ub)
@@ -305,35 +308,35 @@ class TestMapValues:
     def test_from_normalized_validation_invalid(self, random_bounds_valid):
         """Test transformation from the normalized domain with invalid values.
         """
-        my_dom = Domain(random_bounds_valid)
+        dom = Domain(random_bounds_valid)
 
         # Generate random invalid input values in the normalized domain
-        xx = -10 + 3 * np.random.rand(10, my_dom.spatial_dimension)
+        xx = -10 + 3 * np.random.rand(10, dom.spatial_dimension)
 
         # Assertion
         with pytest.raises(ValueError):
-            _ = my_dom.map_from_normalized(xx, validate=True)
+            _ = dom.map_from_internal(xx, validate=True)
 
     def test_from_and_to(self, random_bounds_valid):
         """Test that values are correctly mapped from and to normalized."""
-        my_dom = Domain(random_bounds_valid)
+        dom = Domain(random_bounds_valid)
 
         # Generate random valid input values in the normalized domain
-        xx_1 = -1 + 2 * np.random.rand(10, my_dom.spatial_dimension)
-        yy = my_dom.map_from_normalized(xx_1)
-        xx_2 = my_dom.map_to_normalized(yy)
+        xx_1 = -1 + 2 * np.random.rand(10, dom.spatial_dimension)
+        yy = dom.map_from_internal(xx_1)
+        xx_2 = dom.map_to_internal(yy)
 
         # Assertions
         assert np.allclose(xx_1, xx_2)
 
     def test_to_and_from(self, random_bounds_valid):
         """Test that values are correctly mapped to and from normalized."""
-        my_dom = Domain(random_bounds_valid)
+        dom = Domain(random_bounds_valid)
 
         # Generate random valid input values in the original domain
         xx_1 = generate_values_inbounds(random_bounds_valid)
-        yy = my_dom.map_to_normalized(xx_1)
-        xx_2 = my_dom.map_from_normalized(yy)
+        yy = dom.map_to_internal(xx_1)
+        xx_2 = dom.map_from_internal(yy)
 
         # Assertions
         assert np.allclose(xx_1, xx_2)
@@ -344,12 +347,12 @@ class TestScalingFactor:
 
     def test_integration(self, random_bounds_valid):
         """Test the integration scaling factor."""
-        my_dom = Domain(random_bounds_valid)
+        dom = Domain(random_bounds_valid)
         diff_bounds = random_bounds_valid[:, 1] - random_bounds_valid[:, 0]
 
         assert np.isclose(
-            my_dom.get_int_factor(),
-            np.prod(diff_bounds) / 2**my_dom.spatial_dimension,
+            dom.get_int_factor(),
+            np.prod(diff_bounds) / 2**dom.spatial_dimension,
         )
 
     def test_integration_normalized(self, SpatialDimension):
@@ -507,6 +510,8 @@ class TestUnion:
 
         # Assertions
         assert dom_1 == dom_2
+        print(np.array_equal(dom_2.bounds, dom_3.bounds))
+        print(np.array_equal(dom_2.internal_bounds, dom_3.internal_bounds))
         assert dom_2 == dom_3
         assert dom_3 == dom_4
         assert dom_3 is not dom_4

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -649,7 +649,7 @@ class TestCall:
         # Call the Grid instance
         yy_1 = grd(_fun_one_out, sum=True)
         yy_2 = _fun_one_out(
-            random_unif_domain.map_from_normalized(grd.unisolvent_nodes),
+            random_unif_domain.map_from_internal(grd.unisolvent_nodes),
             sum=True,
         )
 

--- a/tests/test_polynomial.py
+++ b/tests/test_polynomial.py
@@ -307,13 +307,12 @@ class TestExpandDim:
         assert poly_2.multi_index == poly_1.multi_index.expand_dim(new_dim)
         assert poly_2.grid == poly_1.grid.expand_dim(new_dim)
 
-    def test_expand_dim_non_uniform_domain(self, poly_class_all, multi_index_mnp):
+    def test_expand_dim_non_unif_domain(self, poly_class_all, multi_index_mnp):
         """Test dimension expansion in which the domain cannot be extrapolated.
         """
         dim = multi_index_mnp.spatial_dimension
-        # DANGEROUS: For low dimension, UB and LB may be uniform across dims
-        lb = np.random.randint(0, 5, dim)
-        ub = np.random.randint(5, 10, dim)
+        lb = np.random.choice(np.arange(0, 5), size=dim, replace=False)
+        ub = np.random.choice(np.arange(5, 10), size=dim, replace=False)
         domain = Domain(np.c_[lb, ub])
         poly = poly_class_all(multi_index_mnp, domain=domain)
 
@@ -730,8 +729,7 @@ class TestMultiplicationPoly:
             print(poly_1 * poly_2)
 
     def test_non_matching_domain(self, poly_class_all, multi_index_mnp):
-        """Multiplication of polynomials with a non-matching domain raises
-        and exception.
+        """Test that poly multiplication raises error for non-matching domains.
         """
         # Get the complete multi-index set
         mi = multi_index_mnp
@@ -739,17 +737,11 @@ class TestMultiplicationPoly:
         # Create a random set of coefficients
         coeffs = np.random.rand(len(mi))
 
-        # Create a polynomial instance
-        domain_1 = np.ones((2, mi.spatial_dimension))
-        domain_1[0, :] *= -2
-        domain_1[1, :] *= 2
-        dom_1 = Domain(domain_1.T)
-        poly_1 = poly_class_all(mi, coeffs, user_domain=domain_1, domain=dom_1)
-        domain_2 = np.ones((2, mi.spatial_dimension))
-        domain_2[0, :] *= -0.5
-        domain_2[1, :] *= 0.5
-        dom_2 = Domain(domain_2.T)
-        poly_2 = poly_class_all(mi, coeffs, user_domain=domain_2, domain=dom_2)
+        # Create polynomial instances with different domains
+        dom_1 = Domain.uniform(mi.spatial_dimension, lower=0, upper=1)
+        poly_1 = poly_class_all(mi, coeffs, domain=dom_1)
+        dom_2 = Domain.uniform(mi.spatial_dimension, lower=0, upper=0.5)
+        poly_2 = poly_class_all(mi, coeffs, domain=dom_2)
 
         # Perform multiplication
         with pytest.raises(DomainMismatchError):
@@ -1297,8 +1289,7 @@ class TestPolyAdditionSubtraction:
         PolyDegree,
         LpDegree,
     ):
-        """Addition and subtraction of polynomials with a non-matching domain
-        raises an exception.
+        """Test addition and subtraction with non-matching domain raises error.
         """
         # Create a MultiIndexSet
         mi = MultiIndexSet.from_degree(SpatialDimension, PolyDegree, LpDegree)
@@ -1306,17 +1297,11 @@ class TestPolyAdditionSubtraction:
         # Create a random set of coefficients
         coeffs = np.random.rand(len(mi))
 
-        # Create a polynomial instance
-        domain_1 = np.ones((2, SpatialDimension))
-        domain_1[0, :] *= -2
-        domain_1[1, :] *= 2
-        dom_1 = Domain(domain_1.T)
-        poly_1 = poly_class_all(mi, coeffs, user_domain=domain_1, domain=dom_1)
-        domain_2 = np.ones((2, SpatialDimension))
-        domain_2[0, :] *= -0.5
-        domain_2[1, :] *= 0.5
-        dom_2 = Domain(domain_2.T)
-        poly_2 = poly_class_all(mi, coeffs, user_domain=domain_2, domain=dom_2)
+        # Create polynomial instances with different domains
+        dom_1 = Domain.uniform(SpatialDimension, lower=-2, upper=2)
+        poly_1 = poly_class_all(mi, coeffs, domain=dom_1)
+        dom_2 = Domain.uniform(SpatialDimension, lower=0, upper=1)
+        poly_2 = poly_class_all(mi, coeffs, domain=dom_2)
 
         # Assertions
         with pytest.raises(DomainMismatchError):
@@ -2002,17 +1987,11 @@ class TestPolyAdditionSubtractionAugmented:
         # Create a random set of coefficients
         coeffs = np.random.rand(len(mi))
 
-        # Create a polynomial instance with different domains
-        domain_1 = np.ones((2, SpatialDimension))
-        domain_1[0, :] *= -2
-        domain_1[1, :] *= 2
-        dom_1 = Domain(domain_1.T)
-        poly_1 = poly_class_all(mi, coeffs, user_domain=domain_1, domain=dom_1)
-        domain_2 = np.ones((2, SpatialDimension))
-        domain_2[0, :] *= -0.5
-        domain_2[1, :] *= 0.5
-        dom_2 = Domain(domain_2.T)
-        poly_2 = poly_class_all(mi, coeffs, user_domain=domain_2, domain=dom_2)
+        # Create polynomial instances with different domains
+        dom_1 = Domain.uniform(SpatialDimension, lower=0, upper=1)
+        poly_1 = poly_class_all(mi, coeffs, domain=dom_1)
+        dom_2 = Domain.uniform(SpatialDimension, lower=0, upper=2)
+        poly_2 = poly_class_all(mi, coeffs, domain=dom_2)
 
         # Assertions
         with pytest.raises(DomainMismatchError):

--- a/tests/test_polynomial.py
+++ b/tests/test_polynomial.py
@@ -307,37 +307,11 @@ class TestExpandDim:
         assert poly_2.multi_index == poly_1.multi_index.expand_dim(new_dim)
         assert poly_2.grid == poly_1.grid.expand_dim(new_dim)
 
-    # def test_target_dim_new_domains(self, rand_poly_mnp_all):
-    #     """Test dimension expansion of a polynomial with specified domains."""
-    #     # Get the random polynomial
-    #     poly_1 = rand_poly_mnp_all
-    #
-    #     # Get the current and the new dimension
-    #     dim = poly_1.spatial_dimension
-    #     new_dim = dim + 2
-    #
-    #     # Define valid additional domains
-    #     new_domains = np.array([[-2, -2], [2, 2]])
-    #
-    #     # Expand the dimension
-    #     poly_2 = poly_1.expand_dim(
-    #         new_dim,
-    #         extra_internal_domain=new_domains,
-    #         extra_user_domain=new_domains,
-    #     )
-    #
-    #     # Assertions
-    #     assert poly_1 != poly_2
-    #     assert poly_2.spatial_dimension == new_dim
-    #     assert poly_2.multi_index == poly_1.multi_index.expand_dim(new_dim)
-    #     assert poly_2.grid == poly_1.grid.expand_dim(new_dim)
-    #     assert np.array_equal(poly_2.user_domain[:, dim:], new_domains)
-    #     assert np.array_equal(poly_2.internal_domain[:, dim:], new_domains)
-
     def test_expand_dim_non_uniform_domain(self, poly_class_all, multi_index_mnp):
         """Test dimension expansion in which the domain cannot be extrapolated.
         """
         dim = multi_index_mnp.spatial_dimension
+        # DANGEROUS: For low dimension, UB and LB may be uniform across dims
         lb = np.random.randint(0, 5, dim)
         ub = np.random.randint(5, 10, dim)
         domain = Domain(np.c_[lb, ub])
@@ -348,73 +322,6 @@ class TestExpandDim:
 
         with pytest.raises(ValueError):
             poly.expand_dim(dim + 1)
-
-
-    # def test_target_dim_non_uniform_domain(self, poly_mnp_non_unif_domain):
-    #     """Test dimension expansion in which the domain cannot be extrapolated.
-    #     """
-    #     origin_dim = poly_mnp_non_unif_domain.spatial_dimension
-    #     target_dim = origin_dim + 1
-    #
-    #     # Expansion of polynomials w/ a non-uniform domain raises an exception
-    #     with pytest.raises(ValueError):
-    #         poly_mnp_non_unif_domain.expand_dim(target_dim)
-
-    # def test_target_poly_same_dim(self, rand_poly_mnp_all):
-    #     """Test dimension expansion of a polynomial to the dimension of
-    #     another polynomial having the same dimension.
-    #     """
-    #     # Get the random polynomial
-    #     poly_1 = rand_poly_mnp_all
-    #
-    #     # Expand the dimension
-    #     poly_2 = poly_1.expand_dim(poly_1)
-    #
-    #     # Assertions
-    #     assert poly_1 == poly_2
-    #     assert poly_2 == poly_1
-
-    # def test_target_poly_higher_dim(self, poly_mnp_pair_diff_dim):
-    #     """Test dimension expansion of a polynomial to the dimension of another
-    #     polynomial having a higher dimension.
-    #     """
-    #     # Get the polynomial instances
-    #     poly_1, poly_2 = poly_mnp_pair_diff_dim
-    #     # The first polynomial must have smaller dimension
-    #     if poly_1.spatial_dimension > poly_2.spatial_dimension:
-    #         poly_1, poly_2 = poly_2, poly_1
-    #
-    #     # Expand the dimension
-    #     poly_1_exp = poly_1.expand_dim(poly_2)
-    #
-    #     # Assertions
-    #     assert poly_1_exp.has_matching_dimension(poly_2)
-    #     assert poly_1_exp.has_matching_domain(poly_2)
-
-    # def test_target_poly_contraction(self, poly_mnp_pair_diff_dim):
-    #     """Test dimension expansion of a polynomial to the dimension of another
-    #     polynomial having a smaller dimension; this should raise an exception.
-    #     """
-    #     # Get the polynomial instances
-    #     poly_1, poly_2 = poly_mnp_pair_diff_dim
-    #     # The first polynomial must have larger dimension
-    #     if poly_1.spatial_dimension < poly_2.spatial_dimension:
-    #         poly_1, poly_2 = poly_2, poly_1
-    #
-    #     # Expand (contract) the dimension
-    #     with pytest.raises(ValueError):
-    #         poly_1.expand_dim(poly_2)
-    #
-    # def test_target_poly_incompatible_domain(self, poly_mnp_pair_diff_domain):
-    #     """Test dimension expansion of a polynomial to the dimension of another
-    #     polynomial with incompatible internal domain.
-    #     """
-    #     # Get the polynomial instances
-    #     poly_1, poly_2 = poly_mnp_pair_diff_domain
-    #
-    #     # Expanding the dimension to a polynomial with incompatible domain
-    #     with pytest.raises(ValueError):
-    #         poly_1.expand_dim(poly_2)
 
 
 class TestEquality:
@@ -949,46 +856,75 @@ class TestMultiplicationPoly:
     ):
         """Test multiplication with a scalar polynomial with separate indices.
 
-        Some scalar polynomial with separate indices are defined such that
-        the grid remains compatible with the product grid.
-        For instance, the first two Leja-ordered Chebyshev-Lobatto points
-        are the same regardless the degree of the sequence.
-        Multiplication with such a scalar polynomial should be allowed without
-        any transformation.
-        This is an edge case, especially for Newton polynomial.
+        When a non-scalar polynomial is multiplied by a scalar polynomial,
+        the multiplication can proceed without basis transformation if the
+        non-scalar polynomial's generating points are compatible with
+        (i.e., contained within) the product grid's generating points.
+
+        For Leja-ordered Chebyshev-Lobatto points, the first two points
+        remain invariant regardless of the sequence degree. Therefore, if
+        a non-scalar polynomial of degree 0 or 1 has generating points that
+        match the first two points of the product grid (even when the product
+        grid is of higher degree), the product polynomial inherits the same
+        Newton basis and the coefficients are simply scaled
+        by the scalar value.
+
+        Without this compatibility (even for a degree 1 polynomial),
+        if the generating points don't match, the polynomial's representation
+        must be recomputed in the new basis via the divided difference scheme,
+        which this test verifies is avoided when points are compatible.
+
+        This is an edge case particularly relevant for Newton polynomials,
+        where changing the degree typically alters the generating points
+        for unnested grids.
 
         Notes
         -----
         - Instances of `LagrangePolynomial` are excluded from this test as
           it does not support polynomial-polynomial multiplication.
+        - For fully nested grids, this test would work
+         with higher polynomial degrees as all generating points are nested.
+        - A scalar polynomial can have separate indices (i.e., live on a
+          higher-degree grid than necessary for representing a constant).
         """
-        # Create an instance of polynomial
+        # Create a polynomial of degree 0 or 1
         m = SpatialDimension
         p = LpDegree
         poly = poly_class_no_lag.from_degree(m, poly_degree, p)
         poly.coeffs = np.random.rand(len(poly.multi_index), num_polynomials)
 
-        # Create a scalar polynomial (of the same dimension)
+        # Create a scalar polynomial on a compatible grid
+        # The scalar has multi_index with all-zero exponents (degree 0)
         exponents = np.zeros((1, m), dtype=np.int_)
         mi = MultiIndexSet(exponents, p)
-        # Create a Grid based of Leja-ordered Chebyshev-Lobatto points
-        n = 1  # NOTE: the first two points are always the same
-        grd = Grid.from_degree(m, 1, p)
-        # Generate a random scalar
-        scalar = np.random.rand(1)[0]
-        # Repeat the scalar column-wise to match the length of the polynomial
+
+        # Use Leja-ordered Chebyshev-Lobatto grid with degree 5
+        # Key: The first two points (degrees 0-1) of this grid match those
+        # in the poly's grid, making them compatible
+        n = 5
+        grd = Grid.from_degree(m, n, p)
+
+        # Create scalar coefficient matching the number of polynomials
+        scalar = 3 * np.random.rand(1)[0]
         coeffs = np.repeat(scalar, len(poly))[np.newaxis, :]
         poly_scalar = poly.__class__(mi, coeffs, grid=grd)
 
-        # Multiplication
+        # Multiply: scalar has scalar multi_index and compatible grid,
+        # so multiplication proceeds via monomials without transformation
         poly_prod_1 = poly * poly_scalar
         poly_prod_2 = poly_scalar * poly
 
-        # Assertions
+        # Verify the products maintain separate indices & correct coefficients
         assert poly_prod_1.indices_are_separate
         assert poly_prod_2.indices_are_separate
         assert np.all(poly_prod_1.coeffs == poly.coeffs * scalar)
         assert np.all(poly_prod_2.coeffs == poly.coeffs * scalar)
+
+        # Verify numerical correctness by evaluation
+        xx_test = -1 + 2 * np.random.rand(10, SpatialDimension)
+        yy_test_1 = poly_prod_1(xx_test)
+        yy_test_2 = poly(xx_test) * scalar
+        assert np.allclose(yy_test_1, yy_test_2)
 
     def test_inplace(self, rand_poly_mnp_no_lag):
         """Augmented multiplication of polynomials raises an exception.


### PR DESCRIPTION
This PR integrates the `Domain` class into polynomial and grid infrastructure, removing deprecated `internal_domain` and `user_domain properties`. All domain handling is now consolidated through the `Domain` class attached to `Grid` instances.

## Key Changes

**Domain class enhancements**:

- Added internal bounds infrastructure (currently $[-1, 1]^m$)
- Renamed properties for clarity: `lower_bounds` -> `lowers`, `upper_bounds` -> `uppers`, `domain_widths` -> `widths`
- Renamed methods: `map_to_normalized()` -> `map_to_internal()`, `map_from_normalized()` -> `map_from_internal()`
- Added internal parameter to `contains()` for internal vs user domain validation


**Polynomial abstract class cleanup:**

- Removed `internal_domain` and `user_domain` parameters from `__init__()` and all factory methods
- Removed abstract methods `generate_internal_domain()` and `generate_user_domain()`
- Cleaned up unused verification imports

**Grid class refactoring:**

- Verification of generating points now relies on `Domain.contains()` with respect to the internal domain

**Breaking Changes**

- Polynomial constructors no longer accept `internal_domain` or `user_domain` parameters. Use domain parameter with a `Domain` instance instead. Note that a fully-qualified `Grid` instance contains a fully-qualified `Domain` instance.

This PR resolves Issue #69 and partially resolves Issue #53.