### PR TITLE
Add domain-aware polynomial evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Domain-aware polynomial evaluation: `__call__()` now accepts query points in (user) domain with automatic transformation to internal domain (currently [-1, 1]^m)
+- - `eval_on_internal()` method for direct polynomial evaluation in internal domain, bypassing coordinate transformation
 - `Domain` class for handling transformation between user-defined rectangular domains
   and internal (reference) domains
   - Support for coordinate transformations via `map_to_internal()` and `map_from_internal()`
   - Automatic scaling factor computation for differentiation and integration
   - Domain validation via `contains()` method
   - Factory methods: `uniform()` and `normalized()`
+  - The property `is_identity` indicates if the user-defined domain is identical to the internal domain
 - Domain support integrated into `Grid` class
   - `domain` parameter in Grid constructor (defaults to normalized domain in [-1, 1]^m)
   - Grid operations (`*`, `|`) now validate domain consistency

--- a/src/minterpy/core/ABC/multivariate_polynomial_abstract.py
+++ b/src/minterpy/core/ABC/multivariate_polynomial_abstract.py
@@ -16,6 +16,7 @@ import abc
 import numpy as np
 
 from copy import copy, deepcopy
+from numpy.typing import ArrayLike
 from typing import List, Optional, Tuple, Union
 
 from minterpy.global_settings import ARRAY, SCALAR
@@ -25,9 +26,9 @@ from minterpy.core.multi_index import MultiIndexSet
 from minterpy.utils.verification import (
     is_real_scalar,
     shape_eval_output,
+    standardize_query_points,
     verify_poly_coeffs,
     verify_poly_power,
-    verify_query_points,
 )
 from minterpy.utils.multi_index import find_match_between
 from minterpy.utils.exceptions import DomainMismatchError
@@ -136,29 +137,34 @@ class MultivariatePolynomialABC(abc.ABC):
         """
         pass
 
-    def __call__(self, xx: np.ndarray, *, truncate_cols: bool = False, **kwargs) -> np.ndarray:
-        """Evaluate the polynomial on a set of query points.
+    # --- Instance methods: Public
+    def eval_on_internal(
+        self,
+        xx: np.ndarray,
+        *,
+        truncate_cols: bool = False,
+        **kwargs,
+    ) -> np.ndarray:
+        """Evaluate polynomial at points in the internal domain.
 
-        The function is called when an instance of a polynomial is called with
-        a set of query points, i.e., :math:`p(\mathbf{X})` where
-        :math:`\mathbf{X}` is a matrix of values with :math:`k` rows
-        and each row is of length :math:`m` (i.e., a point in
-        :math:`m`-dimensional space).
+        This method evaluates the polynomial at points assumed to already be
+        in the internal domain used by the polynomial's algorithms. It skips
+        coordinate transformation to avoid unnecessary floating-point error
+        accumulation.
 
         Parameters
         ----------
         xx : :class:`numpy:numpy.ndarray`
-            The set of query points to evaluate as a two-dimensional array
-            of shape ``(k, m)`` where ``k`` is the number of query points and
-            ``m`` is the spatial dimension of the polynomial.
+            Query points in the internal domain. It should be a two-dimensional
+            array of shape ``(k, m)`` where ``k`` is the number of query points
+            and ``m`` is the spatial dimension.
         truncate_cols : bool, optional
             If ``True``, then the last columns of ``xx`` are truncated to match
             the spatial dimension of the polynomial; otherwise all provided
-            columns are attempted to be evaluated.
-            The default is ``False``.
+            columns are attempted to be evaluated. The default is ``False``.
         **kwargs
-            Additional keyword-only arguments that change the behavior of
-            the underlying evaluation (see the concrete implementation).
+            Additional keyword-only arguments passed to the underlying
+            evaluation method (see concrete implementation).
 
         Returns
         -------
@@ -175,6 +181,15 @@ class MultivariatePolynomialABC(abc.ABC):
 
         Notes
         -----
+        - Use this method when: (1) Points are already in the internal
+          domain (e.g., unisolvent nodes) (2) Avoiding unnecessary coordinate
+          transformations that incur floating-point errors.
+        - Coordinate transformations are not free numerically. While they
+          are affine, round-trip transformations over many interation may
+          accumulate floating-point errors.
+
+        Notes
+        -----
         - The function calls the concrete implementation of the static method
           ``_eval()``.
 
@@ -183,28 +198,18 @@ class MultivariatePolynomialABC(abc.ABC):
         _eval
             The underlying static method to evaluate the polynomial(s) instance
             on a set of query points.
-
-        TODO
-        ----
-        - Possibly built-in rescaling between ``user_domain`` and
-          ``internal_domain``. An idea: use sklearn min max scaler
-          (``transform()`` and ``inverse_transform()``)
         """
-        # Verify query points
+        # Truncate
         if truncate_cols:
             xx = xx[:, :self.spatial_dimension]
 
-        xx = verify_query_points(xx, self.spatial_dimension)
-
-        # Evaluate using concrete static method
+        # Evaluate using a concrete static method
         yy = self._eval(self, xx, **kwargs)
 
         # Follow the convention of output shape from an evaluation
-        return shape_eval_output(yy)
+        yy = shape_eval_output(yy)
 
-    # anything else any polynomial must support
-    # TODO mathematical operations? abstract
-    # TODO copy operations. abstract
+        return yy
 
 
 class MultivariatePolynomialSingleABC(MultivariatePolynomialABC):
@@ -1153,6 +1158,52 @@ class MultivariatePolynomialSingleABC(MultivariatePolynomialABC):
             return 1
 
         return self.coeffs.shape[1]
+
+    # --- Special methods: Callable instance
+    def __call__(
+        self,
+        xx: ArrayLike,
+        *,
+        truncate_cols: bool = False,
+        **kwargs,
+    ) -> np.ndarray:
+        r"""Evaluate the polynomial on a set of query points.
+
+        The function is called when an instance of a polynomial is called with
+        a set of query points, i.e., :math:`p(\mathbf{X})` where
+        :math:`\mathbf{X}` is a matrix of values with :math:`k` rows
+        and each row is of length :math:`m` (i.e., a point in
+        :math:`m`-dimensional space).
+
+        Parameters
+        ----------
+        xx : array_like
+            Query points to evaluate. Can be a scalar, list, or numpy array.
+            The points will be standardized to a two-dimensional array of
+            shape ``(k, m)`` where ``k`` is the number of query points and
+            ``m`` is the spatial dimension of the polynomial.
+        truncate_cols : bool, optional
+            If ``True``, then the last columns of ``xx`` are truncated to match
+            the spatial dimension of the polynomial; otherwise all provided
+            columns are attempted to be evaluated. The default is ``False``.
+        **kwargs
+            Additional keyword-only arguments that change the behavior of
+            the underlying evaluation (see the concrete implementation).
+
+        Returns
+        -------
+        :class:`numpy:numpy.ndarray`
+            The values of the polynomial evaluated at query points.
+        """
+        # Standardize query points
+        dim = self.spatial_dimension
+        xx = standardize_query_points(xx, dim, truncate_cols=truncate_cols)
+
+        if not self.domain.is_identity:
+            xx = self.domain.map_to_internal(xx)
+
+        # Query points are standardized and truncated
+        return self.eval_on_internal(xx, truncate_cols=False, **kwargs)
 
     # --- Instance methods
     def _new_instance_if_necessary(

--- a/src/minterpy/core/domain.py
+++ b/src/minterpy/core/domain.py
@@ -175,18 +175,20 @@ class Domain:
         return self.uppers - self.lowers
 
     @property
-    def is_normalized(self) -> bool:
-        """Check whether the domain is the same as the internal domain.
+    def is_identity(self) -> bool:
+        """Check whether the domain is (approx) equal to the internal domain.
 
         Returns
         -------
         bool
-            ``True`` if the domain is normalized, ``False`` otherwise.
+            ``True`` if the domain is an identity, ``False`` otherwise.
 
         Notes
         -----
         - This check uses numerical tolerances (``DEFAULT_RTOL`` and
           ``DEFAULT_ATOL``) for robustness against floating-point errors.
+        - When the domain is an identity, transformations and scaling factors
+          computation can usually be skipped.
         """
         # Get the default tolerances
         rtol = DEFAULT_RTOL

--- a/src/minterpy/core/grid.py
+++ b/src/minterpy/core/grid.py
@@ -857,11 +857,12 @@ class Grid:
           there no transformation takes place.
         """
         # No need for type checking the argument; rely on Python to raise any
-        # exceptions when a problematic 'fun' is called on the nodes.
-        if self.domain.is_normalized:
+        # exceptions when problematic 'fun' is called on the nodes.
+        if self.domain.is_identity:
             xx = self.unisolvent_nodes
         else:
             xx = self.domain.map_from_internal(self.unisolvent_nodes)
+
         return fun(xx, *args, **kwargs)
 
     # --- Dunder methods: Rich comparison

--- a/src/minterpy/extras/regression/ordinary_regression.py
+++ b/src/minterpy/extras/regression/ordinary_regression.py
@@ -27,7 +27,7 @@ from minterpy.utils.polynomials.newton import (
     eval_newton_monomials,
     eval_newton_polynomials,
 )
-from minterpy.utils.verification import verify_query_points
+from minterpy.utils.verification import standardize_query_points
 from .regression_abc import RegressionABC
 
 __all__ = ["OrdinaryRegression"]
@@ -330,7 +330,7 @@ class OrdinaryRegression(RegressionABC):
             )
 
         # Verify the training points
-        xx = verify_query_points(xx, self.multi_index.spatial_dimension)
+        xx = standardize_query_points(xx, self.multi_index.spatial_dimension)
 
         # Get the regression matrix on the data points
         self._regression_matrix = self.get_regression_matrix(xx)

--- a/src/minterpy/polynomials/arithmetic.py
+++ b/src/minterpy/polynomials/arithmetic.py
@@ -182,8 +182,9 @@ def _compute_coeffs_poly_add_via_lagrange(
     # Compute the values of the operands at the unisolvent nodes
     # NOTE: The grid may be of higher dimension than one of the polynomials;
     #       evaluation must ignore the extra dimensions
-    lag_coeffs_1 = grid_add(poly_1, truncate_cols=True)
-    lag_coeffs_2 = grid_add(poly_2, truncate_cols=True)
+    nodes_add = grid_add.unisolvent_nodes
+    lag_coeffs_1 = poly_1.eval_on_internal(nodes_add, truncate_cols=True)
+    lag_coeffs_2 = poly_2.eval_on_internal(nodes_add, truncate_cols=True)
     lag_coeffs_add = lag_coeffs_1 + lag_coeffs_2
 
     return lag_coeffs_add
@@ -297,8 +298,9 @@ def _compute_coeffs_poly_mul_via_lagrange(
     # Compute the values of the operands at the unisolvent nodes
     # NOTE: The grid may be of higher dimension than one of the polynomials;
     #       evaluation must ignore the extra dimensions
-    lag_coeffs_1 = grid_mul(poly_1, truncate_cols=True)
-    lag_coeffs_2 = grid_mul(poly_2, truncate_cols=True)
+    nodes_mul = grid_mul.unisolvent_nodes
+    lag_coeffs_1 = poly_1.eval_on_internal(nodes_mul, truncate_cols=True)
+    lag_coeffs_2 = poly_2.eval_on_internal(nodes_mul, truncate_cols=True)
     lag_coeffs_prod = lag_coeffs_1 * lag_coeffs_2
 
     return lag_coeffs_prod

--- a/src/minterpy/utils/verification.py
+++ b/src/minterpy/utils/verification.py
@@ -560,23 +560,30 @@ def verify_poly_coeffs(coeffs: np.ndarray, num_monomials: int) -> np.ndarray:
     return coeffs
 
 
-def verify_query_points(xx: np.ndarray, spatial_dimension: int) -> np.ndarray:
+def standardize_query_points(
+    xx: np.ndarray,
+    spatial_dimension: int,
+    truncate_cols: bool = False,
+) -> np.ndarray:
     r"""Verify if the values of the query points for evaluation are valid.
 
     Parameters
     ----------
     xx : :class:`numpy:numpy.ndarray`
         A one- or two-dimensional array of query points at which a polynomial
-        is evaluated. The length of the array is ``N``, i.e., the number
+        is evaluated. The length of the array is ``k``, i.e., the number
         of query points.
     spatial_dimension : int
         The spatial dimension of the polynomial (``m``).
         The shape of the query points array must be consistent with this.
+    truncate_cols : bool, optional
+        If ``True``, truncate columns to match ``spatial_dimension`` after
+        conversion to array. Default is ``False``.
 
     Returns
     -------
     :class:`numpy:numpy.ndarray`
-        A two-dimensional array of ``numpy.float64`` with a length of ``N``
+        A two-dimensional array of ``numpy.float64`` with a length of ``k``
         and a number of columns of ``m``. If the dtype of the array is not of
         `numpy.float64`, the function does a type conversion if possible.
 
@@ -590,26 +597,28 @@ def verify_query_points(xx: np.ndarray, spatial_dimension: int) -> np.ndarray:
 
     Examples
     --------
-    >>> verify_query_points(1, 1)  # a scalar integer
+    >>> standardize_query_points(1, 1)  # a scalar integer
     array([[1.]])
-    >>> verify_query_points([3., 4., 5.], 1)  # a list
+    >>> standardize_query_points([3., 4., 5.], 1)  # a list
     array([[3.],
            [4.],
            [5.]])
-    >>> verify_query_points([[3, 4, 5]], 3)  # a list of lists of integers
+    >>> standardize_query_points([[3, 4, 5]], 3)  # a list of lists of integers
     array([[3., 4., 5.]])
-    >>> verify_query_points(np.array([1., 2., 3.]), 1)  # 1 dimension
+    >>> standardize_query_points(np.array([1., 2., 3.]), 1)  # 1 dimension
     array([[1.],
            [2.],
            [3.]])
-    >>> verify_query_points(np.array([[1., 2.], [3., 4.]]), 2)  # 2 dimensions
+    >>> standardize_query_points(np.array([[1., 2.], [3., 4.]]), 2)  # 2 dims
     array([[1., 2.],
            [3., 4.]])
-    >>> verify_query_points(np.array([1, 2, 3]), 1)  # integer
+    >>> standardize_query_points(np.array([1, 2, 3]), 1)  # integer
     array([[1.],
            [2.],
            [3.]])
-    >>> verify_query_points(np.array(["a", "b"]), 1) # doctest: +ELLIPSIS
+    >>> standardize_query_points(np.array([[1, 2, 3]]), 2, True)  # Truncate
+    array([[1., 2.]])
+    >>> standardize_query_points(np.array(["a", "b"]), 1) # doctest: +ELLIPSIS
     Traceback (most recent call last):
     ...
     ValueError: could not convert string to float: ...
@@ -629,8 +638,10 @@ def verify_query_points(xx: np.ndarray, spatial_dimension: int) -> np.ndarray:
 
         # Check spatial dimension
         if xx.ndim == 1:
+            xx = xx[:spatial_dimension] if truncate_cols else xx
             dim = 1
         else:
+            xx = xx[:, :spatial_dimension] if truncate_cols else xx
             dim = xx.shape[1]
         dim_is_consistent = dim == spatial_dimension
         if not dim_is_consistent:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,7 @@ POLY_DEGREES = [0, 1, 4]  # NOTE: Include test for poly_degree 0 (Issue #27)
 LP_DEGREES = [0.5, 1.0, 2.0, np.inf]
 
 # Number of coefficient sets in a single polynomial instance
-NUM_POLYS = [1, 2, 5]
+NUM_POLYS = [1, 4]
 
 
 # asserts that a call runs as expected

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -168,9 +168,9 @@ class TestProperties:
         my_dom_3 = Domain(bounds)
 
         # Assertions
-        assert my_dom_1.is_normalized
-        assert my_dom_2.is_normalized
-        assert my_dom_3.is_normalized
+        assert my_dom_1.is_identity
+        assert my_dom_2.is_identity
+        assert my_dom_3.is_identity
         # Normalized domain is always uniform.
         assert my_dom_1.is_uniform
         assert my_dom_2.is_uniform
@@ -181,7 +181,7 @@ class TestProperties:
         my_dom = Domain(random_bounds_valid)
 
         # Assertion
-        assert not my_dom.is_normalized
+        assert not my_dom.is_identity
 
     def test_is_uniform(self, SpatialDimension):
         """Test the uniform property for uniform domain."""
@@ -194,7 +194,7 @@ class TestProperties:
 
         # Assertions
         assert domain.is_uniform
-        assert not domain.is_normalized  # In general not normalized.
+        assert not domain.is_identity  # In general not normalized.
 
     def test_is_not_uniform(self, random_bounds_valid):
         """Test the uniform property for non-uniform domain."""

--- a/tests/test_polynomial.py
+++ b/tests/test_polynomial.py
@@ -25,6 +25,7 @@ from minterpy import (
     LagrangePolynomial,
     MultiIndexSet,
 )
+from minterpy.global_settings import DEFAULT_DOMAIN
 from minterpy.utils.exceptions import DomainMismatchError
 
 
@@ -545,6 +546,42 @@ class TestEvaluation:
             for i in range(num_polynomials):
                 # Due to identical coefficients, results are identical
                 assert np.allclose(yy_test[:, i], yy_test[:, 0])
+
+    def test_different_domains(
+        self,
+        poly_class_no_lag,
+        SpatialDimension,
+        PolyDegree,
+        LpDegree,
+        num_polynomials,
+    ):
+        """Test that domain affects input transformation, not internal poly."""
+        m, n, p = SpatialDimension, PolyDegree, LpDegree
+        mi = MultiIndexSet.from_degree(m, n, p)
+        coeffs = np.arange(len(mi), dtype=float)
+        coeffs = np.repeat(coeffs[:, None], num_polynomials, axis=1)
+
+        # Create a polynomial instance with the default internal domain
+        poly_1 = poly_class_no_lag(mi, coeffs)
+
+        # Create the same polynomial with custom domain
+        lb = np.random.uniform(0, 5, size=m)
+        ub = lb + np.random.uniform(5, 10, size=m)  # Ensure ub > lb
+        domain = Domain(np.c_[lb, ub])
+        poly_2 = poly_class_no_lag(mi, coeffs, domain=domain)
+
+        # Test points in the internal domain
+        lb, ub = DEFAULT_DOMAIN
+        xx_test_1 = lb + (ub - lb) * np.random.rand(100, m)
+
+        # Corresponding points in the custom domain
+        xx_test_2 = poly_2.domain.map_from_internal(xx_test_1)
+
+        # Assertion
+        yy_1 = poly_1(xx_test_1)
+        yy_2 = poly_2(xx_test_2)
+
+        assert np.allclose(yy_1, yy_2)
 
 
 class TestNegation:


### PR DESCRIPTION
Query points passed to polynomial `__call__` are now expected in the polynomial's user domain (default: `[-1, 1]^m`).
Points are automatically transformed to the internal domain before evaluation, eliminating manual coordinate transformations.

The internal polynomial representation remains unchanged and continues to use the internal domain (currently `[-1, 1]^m`).

Key changes:

- Refactor `__call__` to accept user domain points with automatic transformation
- Add `eval_on_internal()` method for direct internal evaluation bypassing transformation
- Rename `Domain.is_normalized` to `Domain.is_identity` for clarity; polynomials whose domain is an identity, does not require any transformation
- Refactor the verification function `verify_query_points()` to `standardize_query_points()` with integrated column truncation
- Update polynomial evaluation tests to verify domain invariance

This PR resolves Issue #54.